### PR TITLE
Fixes for sleep mode / health mode activation / RFC for 8℃ Heating mode

### DIFF
--- a/climate.yaml
+++ b/climate.yaml
@@ -13,6 +13,7 @@
   health: <input_boolean used to switch the Health option on/off of your first AC>
   sleep: <input_boolean used to switch sleep on/off of your first AC>
   powersave: <input_boolean used to switch powersave on/off of your first AC>
+  eightdegheat: <input_boolean used to switch 8 degree heating on/off on your first AC>
 
 - platform: gree
   # required settings:

--- a/custom_components/gree/climate.py
+++ b/custom_components/gree/climate.py
@@ -493,10 +493,6 @@ class GreeClimate(ClimateDevice):
         if new_state.state is self._current_health:
             # do nothing if state change is triggered due to Sync with HVAC
             return
-        if not self._hvac_mode in (HVAC_MODE_COOL, HVAC_MODE_DRY):
-            # do nothing if not in cool or dry mode
-            _LOGGER.info('Cant set health in %s mode' % str(self._hvac_mode))
-            return
         self._async_update_current_health(new_state)
         yield from self.async_update_ha_state()
 


### PR DESCRIPTION
**Fixed sleep mode operation**:

This is a solution to #44 

**Fix Health function activation**:

Currently it is only possible to operate health function in cool and dry mode. This is not a limitation of the device as health function (cold plasma caster) is not dependent on the mode of operation and can be activated/deactivated in every mode. Therefore I propose a change that allows that.

**RFC - 8 deg C Heat function**

This is implementation of RFC #46.

The input_boolean is working, mode is limited only to Heat as on real AC. 
The only thing missing is that when this mode is activated it would be good to display target temp as 8 deg C the same as on the device display. Maybe someone could add this or give me a hint how to do it quickly. Didn't want to mess up the temp refreshing/setting.