### PR TITLE
Support Central ac with gateway

### DIFF
--- a/custom_components/gree/climate.py
+++ b/custom_components/gree/climate.py
@@ -52,6 +52,7 @@ CONF_TCID = 'tcid'
 CONF_SYNC_MODIFIED_ONLY = 'sync_modified_only'
 
 CONF_UNUSE_CMD_TUR = 'unuse_cmd_tur'
+CONF_UNUSE_SWING = 'unuse_swing'
 
 CONF_TARGET_TEMP_STEP = 'target_temp_step'
 CONF_TEMP_SENSOR = 'temp_sensor'
@@ -98,7 +99,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_ENCRYPTION_KEY): cv.string,
     vol.Optional(CONF_UID): cv.positive_int,
     vol.Optional(CONF_SYNC_MODIFIED_ONLY): cv.boolean,
-    vol.Optional(CONF_UNUSE_CMD_TUR): cv.boolean
+    vol.Optional(CONF_UNUSE_CMD_TUR): cv.boolean,
+    vol.Optional(CONF_UNUSE_SWING): cv.boolean
 })
 
 @asyncio.coroutine
@@ -129,15 +131,16 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     sync_modified_only = config.get(CONF_SYNC_MODIFIED_ONLY)
     
     unuse_cmd_tur = config.get(CONF_UNUSE_CMD_TUR)
+    unuse_swing = config.get(CONF_UNUSE_SWING)
     
     _LOGGER.info('Adding Gree climate device to hass')
     async_add_devices([
-        GreeClimate(hass, name, ip_addr, port, mac_addr, tcid, timeout, target_temp_step, temp_sensor_entity_id, lights_entity_id, xfan_entity_id, health_entity_id, powersave_entity_id, sleep_entity_id, eightdegheat_entity_id, air_entity_id, hvac_modes, fan_modes, swing_modes, encryption_key, uid, sync_modified_only, unuse_cmd_tur)
+        GreeClimate(hass, name, ip_addr, port, mac_addr, tcid, timeout, target_temp_step, temp_sensor_entity_id, lights_entity_id, xfan_entity_id, health_entity_id, powersave_entity_id, sleep_entity_id, eightdegheat_entity_id, air_entity_id, hvac_modes, fan_modes, swing_modes, encryption_key, uid, sync_modified_only, unuse_cmd_tur, unuse_swing)
     ])
 
 class GreeClimate(ClimateEntity):
 
-    def __init__(self, hass, name, ip_addr, port, mac_addr, tcid, timeout, target_temp_step, temp_sensor_entity_id, lights_entity_id, xfan_entity_id, health_entity_id, powersave_entity_id, sleep_entity_id, eightdegheat_entity_id, air_entity_id, hvac_modes, fan_modes, swing_modes, encryption_key=None, uid=None, sync_modified_only=None, unuse_cmd_tur=None):
+    def __init__(self, hass, name, ip_addr, port, mac_addr, tcid, timeout, target_temp_step, temp_sensor_entity_id, lights_entity_id, xfan_entity_id, health_entity_id, powersave_entity_id, sleep_entity_id, eightdegheat_entity_id, air_entity_id, hvac_modes, fan_modes, swing_modes, encryption_key=None, uid=None, sync_modified_only=None, unuse_cmd_tur=None, unuse_swing=None):
         _LOGGER.info('Initialize the GREE climate device')
         self.hass = hass
         self._name = name
@@ -201,6 +204,10 @@ class GreeClimate(ClimateEntity):
             self._sync_modified_only = False
             
         self._unuse_cmd_tur = unuse_cmd_tur
+        
+        self.__SUPPORT_FLAGS = SUPPORT_FLAGS
+        if unuse_swing:
+            self.__SUPPORT_FLAGS = SUPPORT_TARGET_TEMPERATURE | SUPPORT_FAN_MODE
         
         self._acOptions = { 'Pow': None, 'Mod': None, 'SetTem': None, 'WdSpd': None, 'Air': None, 'Blo': None, 'Health': None, 'SwhSlp': None, 'Lig': None, 'SwingLfRig': None, 'SwUpDn': None, 'Quiet': None, 'Tur': None, 'StHt': None, 'TemUn': None, 'HeatCoolType': None, 'TemRec': None, 'SvSt': None, 'SlpMod': None }
 
@@ -802,9 +809,9 @@ class GreeClimate(ClimateEntity):
         
     @property
     def supported_features(self):
-        _LOGGER.info('supported_features(): ' + str(SUPPORT_FLAGS))
+        _LOGGER.info('supported_features(): ' + str(self.__SUPPORT_FLAGS))
         # Return the list of supported features.
-        return SUPPORT_FLAGS        
+        return self.__SUPPORT_FLAGS        
  
     def set_temperature(self, **kwargs):
         _LOGGER.info('set_temperature(): ' + str(kwargs.get(ATTR_TEMPERATURE)))

--- a/custom_components/gree/climate.py
+++ b/custom_components/gree/climate.py
@@ -85,7 +85,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
     vol.Required(CONF_PORT, default=DEFAULT_PORT): cv.positive_int,
     vol.Required(CONF_MAC): cv.string,
-    vol.Optional(CONF_TCID): cv.string,
+    vol.Optional(CONF_TCID, default=''): cv.string,
     vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): cv.positive_int,
     vol.Optional(CONF_TARGET_TEMP_STEP, default=DEFAULT_TARGET_TEMP_STEP): vol.Coerce(float),
     vol.Optional(CONF_TEMP_SENSOR): cv.entity_id,
@@ -98,9 +98,9 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_AIR): cv.entity_id,
     vol.Optional(CONF_ENCRYPTION_KEY): cv.string,
     vol.Optional(CONF_UID): cv.positive_int,
-    vol.Optional(CONF_SYNC_MODIFIED_ONLY): cv.boolean,
-    vol.Optional(CONF_UNUSE_CMD_TUR): cv.boolean,
-    vol.Optional(CONF_UNUSE_SWING): cv.boolean
+    vol.Optional(CONF_SYNC_MODIFIED_ONLY, default=False): cv.boolean,
+    vol.Optional(CONF_UNUSE_CMD_TUR, default=False): cv.boolean,
+    vol.Optional(CONF_UNUSE_SWING, default=False): cv.boolean
 })
 
 @asyncio.coroutine
@@ -135,12 +135,12 @@ def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
     
     _LOGGER.info('Adding Gree climate device to hass')
     async_add_devices([
-        GreeClimate(hass, name, ip_addr, port, mac_addr, tcid, timeout, target_temp_step, temp_sensor_entity_id, lights_entity_id, xfan_entity_id, health_entity_id, powersave_entity_id, sleep_entity_id, eightdegheat_entity_id, air_entity_id, hvac_modes, fan_modes, swing_modes, encryption_key, uid, sync_modified_only, unuse_cmd_tur, unuse_swing)
+        GreeClimate(hass, name, ip_addr, port, mac_addr, tcid, timeout, target_temp_step, temp_sensor_entity_id, lights_entity_id, xfan_entity_id, health_entity_id, powersave_entity_id, sleep_entity_id, eightdegheat_entity_id, air_entity_id, hvac_modes, fan_modes, swing_modes, sync_modified_only, unuse_cmd_tur, unuse_swing, encryption_key, uid)
     ])
 
 class GreeClimate(ClimateEntity):
 
-    def __init__(self, hass, name, ip_addr, port, mac_addr, tcid, timeout, target_temp_step, temp_sensor_entity_id, lights_entity_id, xfan_entity_id, health_entity_id, powersave_entity_id, sleep_entity_id, eightdegheat_entity_id, air_entity_id, hvac_modes, fan_modes, swing_modes, encryption_key=None, uid=None, sync_modified_only=None, unuse_cmd_tur=None, unuse_swing=None):
+    def __init__(self, hass, name, ip_addr, port, mac_addr, tcid, timeout, target_temp_step, temp_sensor_entity_id, lights_entity_id, xfan_entity_id, health_entity_id, powersave_entity_id, sleep_entity_id, eightdegheat_entity_id, air_entity_id, hvac_modes, fan_modes, swing_modes, sync_modified_only, unuse_cmd_tur, unuse_swing, encryption_key=None, uid=None):
         _LOGGER.info('Initialize the GREE climate device')
         self.hass = hass
         self._name = name
@@ -183,6 +183,7 @@ class GreeClimate(ClimateEntity):
         if tcid:
             self._tcid = tcid.encode("utf8").replace(b':', b'').decode('utf-8').lower()
             self._is_sub_device = True
+            _LOGGER.info('This device is marked as a sub-device over the gateway: {}'.format(self._tcid))
         else:
             self._tcid = self._mac_addr
 
@@ -197,12 +198,8 @@ class GreeClimate(ClimateEntity):
             self._uid = uid
         else:
             self._uid = 0
-        
-        if sync_modified_only:
-            self._sync_modified_only = sync_modified_only
-        else:
-            self._sync_modified_only = False
-            
+
+        self._sync_modified_only = sync_modified_only
         self._unuse_cmd_tur = unuse_cmd_tur
         
         self.__SUPPORT_FLAGS = SUPPORT_FLAGS


### PR DESCRIPTION
I use a Gree central air conditioner sold in China, which uses a gateway to communicate with every sub-device.
This gateway is called "格力云控" and  the version I have is 2.
Here, the gateway is the parent device, and each air conditioner is the child device. To get or change the settings for each air conditioner requires communication with the gateway.
The communication format is basically the same as other air conditioners, but a little difference is as follows.

> tcid: the gateway mac address
> mac: the sub-device mac address

This modification works fine on my device, and sorry for my bad English.
