### PR TITLE
Support turn_on

### DIFF
--- a/custom_components/gree/climate.py
+++ b/custom_components/gree/climate.py
@@ -792,6 +792,12 @@ class GreeClimate(ClimateEntity):
             self.SyncState({'Mod': self._hvac_modes.index(hvac_mode), 'Pow': 1})
         self.schedule_update_ha_state()
 
+    def turn_on(self):
+        _LOGGER.info('turn_on(): ')
+        # Turn on.
+        self.SyncState({'Pow': 1})
+        self.schedule_update_ha_state()
+
     async def async_added_to_hass(self):
         _LOGGER.info('Gree climate device added to hass()')
         self.SyncState()


### PR DESCRIPTION
Without this, calling climate.turn_on will always set climate mode to heat, see home-assistant climate component source code here https://github.com/home-assistant/core/blob/40b5605cafcf81925c6066545b0bc226ee78a4e4/homeassistant/components/climate/__init__.py#L546