### PR TITLE
async_track_state_change -> async_track_state_change_eventaccording

### DIFF
--- a/custom_components/gree/climate.py
+++ b/custom_components/gree/climate.py
@@ -577,7 +577,7 @@ class GreeClimate(ClimateEntity):
             return
         _LOGGER.error('Unable to update from health_entity!')
 
-    async def _async_health_entity_state_changed(self, event: Event[EventStateChangedData]) -> None:
+    async def _async_powersave_entity_state_changed(self, event: Event[EventStateChangedData]) -> None:
         entity_id = event.data["entity_id"]
         old_state = event.data["old_state"]
         new_state = event.data["new_state"]


### PR DESCRIPTION
changed async_track_state_change with async_track_state_change_eventaccording to  https://developers.home-assistant.io/blog/2024/04/13/deprecate_async_track_state_change/