### PR TITLE
Horizontal swing, new climate entity flags

### DIFF
--- a/custom_components/gree/climate.py
+++ b/custom_components/gree/climate.py
@@ -577,7 +577,7 @@ class GreeClimate(ClimateEntity):
             return
         _LOGGER.error('Unable to update from health_entity!')
 
-    async def _async_health_entity_state_changed(self, event: Event[EventStateChangedData]) -> None:
+    async def _async_powersave_entity_state_changed(self, event: Event[EventStateChangedData]) -> None:
         entity_id = event.data["entity_id"]
         old_state = event.data["old_state"]
         new_state = event.data["new_state"]

--- a/custom_components/gree/climate.py
+++ b/custom_components/gree/climate.py
@@ -49,7 +49,7 @@ REQUIREMENTS = ['pycryptodome']
 
 _LOGGER = logging.getLogger(__name__)
 
-SUPPORT_FLAGS = ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.FAN_MODE | ClimateEntityFeature.SWING_MODE
+SUPPORT_FLAGS = ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.FAN_MODE | ClimateEntityFeature.SWING_MODE | ClimateEntityFeature.PRESET_MODE | ClimateEntityFeature.TURN_ON | ClimateEntityFeature.TURN_OFF
 
 DEFAULT_NAME = 'Gree Climate'
 
@@ -78,7 +78,7 @@ HVAC_MODES = [HVACMode.AUTO, HVACMode.COOL, HVACMode.DRY, HVACMode.FAN_ONLY, HVA
 
 FAN_MODES = ['Auto', 'Low', 'Medium-Low', 'Medium', 'Medium-High', 'High', 'Turbo', 'Quiet']
 SWING_MODES = ['Default', 'Swing in full range', 'Fixed in the upmost position', 'Fixed in the middle-up position', 'Fixed in the middle position', 'Fixed in the middle-low position', 'Fixed in the lowest position', 'Swing in the downmost region', 'Swing in the middle-low region', 'Swing in the middle region', 'Swing in the middle-up region', 'Swing in the upmost region']
-PRESET_MODES = ['Default', 'Full swing', 'Fixed in the leftmost position', 'Fixed in the middleleft position', 'Fixed in the middle postion','Fixed in the middleright position', 'Fixed in the rightmost position']
+PRESET_MODES = ['Default', 'Full swing', 'Fixed in the leftmost position', 'Fixed in the middle-left position', 'Fixed in the middle postion','Fixed in the middle-right position', 'Fixed in the rightmost position']
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
@@ -119,17 +119,18 @@ async def async_setup_platform(hass, config, async_add_devices, discovery_info=N
     hvac_modes = HVAC_MODES
     fan_modes = FAN_MODES
     swing_modes = SWING_MODES
+    preset_modes = PRESET_MODES
     encryption_key = config.get(CONF_ENCRYPTION_KEY)
     uid = config.get(CONF_UID)
     
     _LOGGER.info('Adding Gree climate device to hass')
     async_add_devices([
-        GreeClimate(hass, name, ip_addr, port, mac_addr, timeout, target_temp_step, temp_sensor_entity_id, lights_entity_id, xfan_entity_id, health_entity_id, powersave_entity_id, sleep_entity_id, eightdegheat_entity_id, air_entity_id, hvac_modes, fan_modes, swing_modes, encryption_key, uid)
+        GreeClimate(hass, name, ip_addr, port, mac_addr, timeout, target_temp_step, temp_sensor_entity_id, lights_entity_id, xfan_entity_id, health_entity_id, powersave_entity_id, sleep_entity_id, eightdegheat_entity_id, air_entity_id, hvac_modes, fan_modes, swing_modes, preset_modes, encryption_key, uid)
     ])
 
 class GreeClimate(ClimateEntity):
 
-    def __init__(self, hass, name, ip_addr, port, mac_addr, timeout, target_temp_step, temp_sensor_entity_id, lights_entity_id, xfan_entity_id, health_entity_id, powersave_entity_id, sleep_entity_id, eightdegheat_entity_id, air_entity_id, hvac_modes, fan_modes, swing_modes, encryption_key=None, uid=None):
+    def __init__(self, hass, name, ip_addr, port, mac_addr, timeout, target_temp_step, temp_sensor_entity_id, lights_entity_id, xfan_entity_id, health_entity_id, powersave_entity_id, sleep_entity_id, eightdegheat_entity_id, air_entity_id, hvac_modes, fan_modes, swing_modes, preset_modes, encryption_key=None, uid=None):
         _LOGGER.info('Initialize the GREE climate device')
         self.hass = hass
         self._name = name
@@ -155,6 +156,7 @@ class GreeClimate(ClimateEntity):
         self._hvac_mode = None
         self._fan_mode = None
         self._swing_mode = None
+        self._preset_mode = None
         self._current_lights = None
         self._current_xfan = None
         self._current_health = None
@@ -166,6 +168,9 @@ class GreeClimate(ClimateEntity):
         self._hvac_modes = hvac_modes
         self._fan_modes = fan_modes
         self._swing_modes = swing_modes
+        self._preset_modes = preset_modes
+
+        self._enable_turn_on_off_backwards_compatibility = False
 
         if encryption_key:
             _LOGGER.info('Using configured encryption key: {}'.format(encryption_key))
@@ -419,6 +424,11 @@ class GreeClimate(ClimateEntity):
         # Sync current HVAC Swing mode state to HA
         self._swing_mode = self._swing_modes[self._acOptions['SwUpDn']]
         _LOGGER.info('HA swing mode set according to HVAC state to: ' + str(self._swing_mode))
+    
+    def UpdateHACurrentPresetMode(self):
+        # Sync current HVAC preset mode state to HA
+        self._preset_mode = self._preset_modes[self._acOptions['SwingLfRig']]
+        _LOGGER.info('HA preset mode set according to HVAC state to: ' + str(self._preset_mode))
 
     def UpdateHAFanMode(self):
         # Sync current HVAC Fan mode state to HA
@@ -435,6 +445,7 @@ class GreeClimate(ClimateEntity):
         self.UpdateHAOptions()
         self.UpdateHAHvacMode()
         self.UpdateHACurrentSwingMode()
+        self.UpdateHACurrentPresetMode()
         self.UpdateHAFanMode()
 
     def SyncState(self, acOptions = {}):
@@ -761,6 +772,18 @@ class GreeClimate(ClimateEntity):
         return self._swing_modes
 
     @property
+    def preset_mode(self):
+        _LOGGER.info('preset_mode(): ' + str(self._preset_mode))
+        # get the current preset mode
+        return self._preset_mode
+
+    @property
+    def preset_modes(self):
+        _LOGGER.info('preset_modes(): ' + str(self._preset_modes))
+        # get the list of available preset modes
+        return self._preset_modes
+
+    @property
     def hvac_modes(self):
         _LOGGER.info('hvac_modes(): ' + str(self._hvac_modes))
         # Return the list of available operation modes.
@@ -782,8 +805,13 @@ class GreeClimate(ClimateEntity):
     def supported_features(self):
         _LOGGER.info('supported_features(): ' + str(SUPPORT_FLAGS))
         # Return the list of supported features.
-        return SUPPORT_FLAGS        
- 
+        return SUPPORT_FLAGS
+
+    @property
+    def unique_id(self):
+        # Return unique_id
+        return self._unique_id
+
     def set_temperature(self, **kwargs):
         _LOGGER.info('set_temperature(): ' + str(kwargs.get(ATTR_TEMPERATURE)))
         # Set new target temperatures.
@@ -802,6 +830,15 @@ class GreeClimate(ClimateEntity):
             # do nothing if HVAC is switched off
             _LOGGER.info('SyncState with SwUpDn=' + str(swing_mode))
             self.SyncState({'SwUpDn': self._swing_modes.index(swing_mode)})
+            self.schedule_update_ha_state()
+
+    def set_preset_mode(self, swing_mode):
+        _LOGGER.info('Set preset mode(): ' + str(preset_mode))
+        # set the preset mode
+        if not (self._acOptions['Pow'] == 0):
+            # do nothing if HVAC is switched off
+            _LOGGER.info('SyncState with SwingLfRig=' + str(preset_mode))
+            self.SyncState({'SwingLfRig': self._preset_modes.index(preset_mode)})
             self.schedule_update_ha_state()
 
     def set_fan_mode(self, fan):
@@ -834,11 +871,12 @@ class GreeClimate(ClimateEntity):
         self.SyncState({'Pow': 1})
         self.schedule_update_ha_state()
 
+    def turn_off(self):
+        _LOGGER.info('turn_off(): ')
+        # Turn on.
+        self.SyncState({'Pow': 0})
+        self.schedule_update_ha_state()
+
     async def async_added_to_hass(self):
         _LOGGER.info('Gree climate device added to hass()')
         self.SyncState()
-
-    @property
-    def unique_id(self):
-        # Return unique_id
-        return self._unique_id

--- a/custom_components/gree/climate.py
+++ b/custom_components/gree/climate.py
@@ -832,7 +832,7 @@ class GreeClimate(ClimateEntity):
             self.SyncState({'SwUpDn': self._swing_modes.index(swing_mode)})
             self.schedule_update_ha_state()
 
-    def set_preset_mode(self, swing_mode):
+    def set_preset_mode(self, preset_mode):
         _LOGGER.info('Set preset mode(): ' + str(preset_mode))
         # set the preset mode
         if not (self._acOptions['Pow'] == 0):

--- a/custom_components/gree/climate.py
+++ b/custom_components/gree/climate.py
@@ -13,18 +13,29 @@ import os.path
 import voluptuous as vol
 import homeassistant.helpers.config_validation as cv
 
-from homeassistant.components.climate import (ClimateEntity, PLATFORM_SCHEMA)
-
-from homeassistant.components.climate.const import (
-    HVAC_MODE_OFF, HVAC_MODE_AUTO, HVAC_MODE_COOL, HVAC_MODE_DRY,
-    HVAC_MODE_FAN_ONLY, HVAC_MODE_HEAT, SUPPORT_FAN_MODE,
-    SUPPORT_TARGET_TEMPERATURE, SUPPORT_SWING_MODE)
+from homeassistant.components.climate import (
+    ClimateEntity,
+    ClimateEntityFeature,
+    HVACMode,
+    PLATFORM_SCHEMA
+)
 
 from homeassistant.const import (
-    ATTR_UNIT_OF_MEASUREMENT, ATTR_TEMPERATURE, 
-    CONF_NAME, CONF_HOST, CONF_PORT, CONF_MAC, CONF_TIMEOUT, CONF_CUSTOMIZE, 
-    STATE_ON, STATE_OFF, STATE_UNKNOWN, 
-    TEMP_CELSIUS, PRECISION_WHOLE, PRECISION_TENTHS)
+    ATTR_TEMPERATURE, 
+    ATTR_UNIT_OF_MEASUREMENT,
+    CONF_CUSTOMIZE,
+    CONF_HOST,
+    CONF_MAC,
+    CONF_NAME,
+    CONF_PORT,
+    CONF_TIMEOUT,
+    PRECISION_TENTHS,
+    PRECISION_WHOLE,
+    STATE_OFF, 
+    STATE_ON,
+    STATE_UNKNOWN,
+    UnitOfTemperature
+)
 
 from homeassistant.helpers.event import (async_track_state_change)
 from homeassistant.core import callback
@@ -38,7 +49,7 @@ REQUIREMENTS = ['pycryptodome']
 
 _LOGGER = logging.getLogger(__name__)
 
-SUPPORT_FLAGS = SUPPORT_TARGET_TEMPERATURE | SUPPORT_FAN_MODE | SUPPORT_SWING_MODE
+SUPPORT_FLAGS = ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.FAN_MODE | ClimateEntityFeature.SWING_MODE
 
 DEFAULT_NAME = 'Gree Climate'
 
@@ -63,7 +74,7 @@ MIN_TEMP = 16
 MAX_TEMP = 30
 
 # fixed values in gree mode lists
-HVAC_MODES = [HVAC_MODE_AUTO, HVAC_MODE_COOL, HVAC_MODE_DRY, HVAC_MODE_FAN_ONLY, HVAC_MODE_HEAT, HVAC_MODE_OFF]
+HVAC_MODES = [HVACMode.AUTO, HVACMode.COOL, HVACMode.DRY, HVACMode.FAN_ONLY, HVACMode.HEAT, HVACMode.OFF]
 
 FAN_MODES = ['Auto', 'Low', 'Medium-Low', 'Medium', 'Medium-High', 'High', 'Turbo', 'Quiet']
 SWING_MODES = ['Default', 'Swing in full range', 'Fixed in the upmost position', 'Fixed in the middle-up position', 'Fixed in the middle position', 'Fixed in the middle-low position', 'Fixed in the lowest position', 'Swing in the downmost region', 'Swing in the middle-low region', 'Swing in the middle region', 'Swing in the middle-up region', 'Swing in the upmost region']
@@ -398,7 +409,7 @@ class GreeClimate(ClimateEntity):
     def UpdateHAHvacMode(self):
         # Sync current HVAC operation mode to HA
         if (self._acOptions['Pow'] == 0):
-            self._hvac_mode = HVAC_MODE_OFF
+            self._hvac_mode = HVACMode.OFF
         else:
             self._hvac_mode = self._hvac_modes[self._acOptions['Mod']]
         _LOGGER.info('HA operation mode set according to HVAC state to: ' + str(self._hvac_mode))
@@ -515,7 +526,7 @@ class GreeClimate(ClimateEntity):
         if new_state.state is self._current_xfan:
             # do nothing if state change is triggered due to Sync with HVAC
             return
-        if not self._hvac_mode in (HVAC_MODE_COOL, HVAC_MODE_DRY):
+        if not self._hvac_mode in (HVACMode.COOL, HVACMode.DRY):
             # do nothing if not in cool or dry mode
             _LOGGER.info('Cant set xfan in %s mode' % str(self._hvac_mode))
             return
@@ -561,7 +572,7 @@ class GreeClimate(ClimateEntity):
         if new_state.state is self._current_powersave:
             # do nothing if state change is triggered due to Sync with HVAC
             return
-        if not self._hvac_mode in (HVAC_MODE_COOL):
+        if not self._hvac_mode in (HVACMode.COOL):
             # do nothing if not in cool mode
             _LOGGER.info('Cant set powersave in %s mode' % str(self._hvac_mode))
             return
@@ -587,7 +598,7 @@ class GreeClimate(ClimateEntity):
         if new_state.state is self._current_sleep:
             # do nothing if state change is triggered due to Sync with HVAC
             return
-        if not self._hvac_mode in (HVAC_MODE_COOL, HVAC_MODE_HEAT):
+        if not self._hvac_mode in (HVACMode.COOL, HVACMode.HEAT):
             # do nothing if not in cool or heat mode
             _LOGGER.info('Cant set sleep in %s mode' % str(self._hvac_mode))
             return
@@ -612,7 +623,7 @@ class GreeClimate(ClimateEntity):
         if new_state.state is self._current_eightdegheat:
             # do nothing if state change is triggered due to Sync with HVAC
             return
-        if not self._hvac_mode in (HVAC_MODE_HEAT):
+        if not self._hvac_mode in (HVACMode.HEAT):
             # do nothing if not in heat mode
             _LOGGER.info('Cant set 8℃ heat in %s mode' % str(self._hvac_mode))
             return
@@ -786,7 +797,7 @@ class GreeClimate(ClimateEntity):
     def set_hvac_mode(self, hvac_mode):
         _LOGGER.info('set_hvac_mode(): ' + str(hvac_mode))
         # Set new operation mode.
-        if (hvac_mode == HVAC_MODE_OFF):
+        if (hvac_mode == HVACMode.OFF):
             self.SyncState({'Pow': 0})
         else:
             self.SyncState({'Mod': self._hvac_modes.index(hvac_mode), 'Pow': 1})

--- a/custom_components/gree/climate.py
+++ b/custom_components/gree/climate.py
@@ -78,6 +78,7 @@ HVAC_MODES = [HVACMode.AUTO, HVACMode.COOL, HVACMode.DRY, HVACMode.FAN_ONLY, HVA
 
 FAN_MODES = ['Auto', 'Low', 'Medium-Low', 'Medium', 'Medium-High', 'High', 'Turbo', 'Quiet']
 SWING_MODES = ['Default', 'Swing in full range', 'Fixed in the upmost position', 'Fixed in the middle-up position', 'Fixed in the middle position', 'Fixed in the middle-low position', 'Fixed in the lowest position', 'Swing in the downmost region', 'Swing in the middle-low region', 'Swing in the middle region', 'Swing in the middle-up region', 'Swing in the upmost region']
+PRESET_MODES = ['Default', 'Full swing', 'Fixed in the leftmost position', 'Fixed in the middleleft position', 'Fixed in the middle postion','Fixed in the middleright position', 'Fixed in the rightmost position']
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,


### PR DESCRIPTION
- Added support for horizontal swing. Since ha's climate entity doesn't support horizontal swing, to enable operation on units that have this feature, component uses preset modes.
- Added support for new climate entity flags - TURN_ON, TURN_OFF according to https://developers.home-assistant.io/blog/2024/01/24/climate-climateentityfeatures-expanded/