### PR TITLE
Add support for auto_light and auto_xfan

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Tested on the following hardware:
 - CASCADE BORA-CWH09AAB
 - EWT S-090 GDI-HRFN1, EWT S-120 GDI-HRFN1 (WI-FI module CS532AEH)
 - Tadiran Alpha Expert Inverter
+- Copmax Air-Air Heatpump GWH12QC-K6DNA5F 3.5kW
 
 Tested on these Home Assistant versions:
 - 0.96.x+ (for older versions, please see the releases tab)
@@ -61,6 +62,9 @@ This component is added to HACS default repository list.
      powersave: <OPTIONAL: input_boolean to switch AC powersave mode on/off. For example: input_boolean.first_ac_powersave>
      eightdegheat: <OPTIONAL: input_boolean used to switch 8 degree heating on/off on your first AC>
      air: <OPTIONAL: input_boolean used to switch air/scavenging on/off on your first AC>
+     target_temp: <OPTIONAL: input_number used to set the temperature of your first AC. This is usefull if you want to use dashboards with custom frontend components>
+     auto_xfan: <OPTIONAL: boolean (true/false); this feature will always turn on xFan in cool and dry mode to avoid mold & rust created from potential water buildup in the AC>
+     auto_light: <OPTIONAL: boolean (true/false); this feature will always turn light on when power on and turn light light off when power off automatically> 
    
    - platform: gree
      name: Second AC

--- a/custom_components/gree/climate.py
+++ b/custom_components/gree/climate.py
@@ -893,13 +893,19 @@ class GreeClimate(ClimateEntity):
     def turn_on(self):
         _LOGGER.info('turn_on(): ')
         # Turn on.
-        self.SyncState({'Pow': 1})
+        c = {'Pow': 1}
+        if self._auto_light:
+            c.update({'Lig': 1})
+        self.SyncState(c)
         self.schedule_update_ha_state()
 
     def turn_off(self):
         _LOGGER.info('turn_off(): ')
-        # Turn on.
-        self.SyncState({'Pow': 0})
+        # Turn off.
+        c = {'Pow': 0}
+        if self._auto_light:
+            c.update({'Lig': 0})
+        self.SyncState(c)
         self.schedule_update_ha_state()
 
     async def async_added_to_hass(self):

--- a/custom_components/gree/climate.py
+++ b/custom_components/gree/climate.py
@@ -577,7 +577,7 @@ class GreeClimate(ClimateEntity):
             return
         _LOGGER.error('Unable to update from health_entity!')
 
-    async def _async_health_entity_state_changed(self, event: Event[EventStateChangedData]) -> None:
+    async def _async_powersave_entity_state_changed(self, event: Event[EventStateChangedData]) -> None:
         entity_id = event.data["entity_id"]
         old_state = event.data["old_state"]
         new_state = event.data["new_state"]

--- a/custom_components/gree/climate.py
+++ b/custom_components/gree/climate.py
@@ -49,7 +49,7 @@ REQUIREMENTS = ['pycryptodome']
 
 _LOGGER = logging.getLogger(__name__)
 
-SUPPORT_FLAGS = ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.FAN_MODE | ClimateEntityFeature.SWING_MODE
+SUPPORT_FLAGS = ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.FAN_MODE | ClimateEntityFeature.SWING_MODE | ClimateEntityFeature.PRESET_MODE | ClimateEntityFeature.TURN_ON | ClimateEntityFeature.TURN_OFF
 
 DEFAULT_NAME = 'Gree Climate'
 
@@ -78,7 +78,7 @@ HVAC_MODES = [HVACMode.AUTO, HVACMode.COOL, HVACMode.DRY, HVACMode.FAN_ONLY, HVA
 
 FAN_MODES = ['Auto', 'Low', 'Medium-Low', 'Medium', 'Medium-High', 'High', 'Turbo', 'Quiet']
 SWING_MODES = ['Default', 'Swing in full range', 'Fixed in the upmost position', 'Fixed in the middle-up position', 'Fixed in the middle position', 'Fixed in the middle-low position', 'Fixed in the lowest position', 'Swing in the downmost region', 'Swing in the middle-low region', 'Swing in the middle region', 'Swing in the middle-up region', 'Swing in the upmost region']
-PRESET_MODES = ['Default', 'Full swing', 'Fixed in the leftmost position', 'Fixed in the middleleft position', 'Fixed in the middle postion','Fixed in the middleright position', 'Fixed in the rightmost position']
+PRESET_MODES = ['Default', 'Full swing', 'Fixed in the leftmost position', 'Fixed in the middle-left position', 'Fixed in the middle postion','Fixed in the middle-right position', 'Fixed in the rightmost position']
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
@@ -119,17 +119,18 @@ async def async_setup_platform(hass, config, async_add_devices, discovery_info=N
     hvac_modes = HVAC_MODES
     fan_modes = FAN_MODES
     swing_modes = SWING_MODES
+    preset_modes = PRESET_MODES
     encryption_key = config.get(CONF_ENCRYPTION_KEY)
     uid = config.get(CONF_UID)
     
     _LOGGER.info('Adding Gree climate device to hass')
     async_add_devices([
-        GreeClimate(hass, name, ip_addr, port, mac_addr, timeout, target_temp_step, temp_sensor_entity_id, lights_entity_id, xfan_entity_id, health_entity_id, powersave_entity_id, sleep_entity_id, eightdegheat_entity_id, air_entity_id, hvac_modes, fan_modes, swing_modes, encryption_key, uid)
+        GreeClimate(hass, name, ip_addr, port, mac_addr, timeout, target_temp_step, temp_sensor_entity_id, lights_entity_id, xfan_entity_id, health_entity_id, powersave_entity_id, sleep_entity_id, eightdegheat_entity_id, air_entity_id, hvac_modes, fan_modes, swing_modes, preset_modes, encryption_key, uid)
     ])
 
 class GreeClimate(ClimateEntity):
 
-    def __init__(self, hass, name, ip_addr, port, mac_addr, timeout, target_temp_step, temp_sensor_entity_id, lights_entity_id, xfan_entity_id, health_entity_id, powersave_entity_id, sleep_entity_id, eightdegheat_entity_id, air_entity_id, hvac_modes, fan_modes, swing_modes, encryption_key=None, uid=None):
+    def __init__(self, hass, name, ip_addr, port, mac_addr, timeout, target_temp_step, temp_sensor_entity_id, lights_entity_id, xfan_entity_id, health_entity_id, powersave_entity_id, sleep_entity_id, eightdegheat_entity_id, air_entity_id, hvac_modes, fan_modes, swing_modes, preset_modes, encryption_key=None, uid=None):
         _LOGGER.info('Initialize the GREE climate device')
         self.hass = hass
         self._name = name
@@ -155,6 +156,7 @@ class GreeClimate(ClimateEntity):
         self._hvac_mode = None
         self._fan_mode = None
         self._swing_mode = None
+        self._preset_mode = None
         self._current_lights = None
         self._current_xfan = None
         self._current_health = None
@@ -166,6 +168,9 @@ class GreeClimate(ClimateEntity):
         self._hvac_modes = hvac_modes
         self._fan_modes = fan_modes
         self._swing_modes = swing_modes
+        self._preset_modes = preset_modes
+
+        self._enable_turn_on_off_backwards_compatibility = False
 
         if encryption_key:
             _LOGGER.info('Using configured encryption key: {}'.format(encryption_key))
@@ -419,6 +424,11 @@ class GreeClimate(ClimateEntity):
         # Sync current HVAC Swing mode state to HA
         self._swing_mode = self._swing_modes[self._acOptions['SwUpDn']]
         _LOGGER.info('HA swing mode set according to HVAC state to: ' + str(self._swing_mode))
+    
+    def UpdateHACurrentPresetMode(self):
+        # Sync current HVAC preset mode state to HA
+        self._preset_mode = self._preset_modes[self._acOptions['SwingLfRig']]
+        _LOGGER.info('HA preset mode set according to HVAC state to: ' + str(self._preset_mode))
 
     def UpdateHAFanMode(self):
         # Sync current HVAC Fan mode state to HA
@@ -435,6 +445,7 @@ class GreeClimate(ClimateEntity):
         self.UpdateHAOptions()
         self.UpdateHAHvacMode()
         self.UpdateHACurrentSwingMode()
+        self.UpdateHACurrentPresetMode()
         self.UpdateHAFanMode()
 
     def SyncState(self, acOptions = {}):
@@ -761,6 +772,18 @@ class GreeClimate(ClimateEntity):
         return self._swing_modes
 
     @property
+    def preset_mode(self):
+        _LOGGER.info('preset_mode(): ' + str(self._preset_mode))
+        # get the current preset mode
+        return self._preset_mode
+
+    @property
+    def preset_modes(self):
+        _LOGGER.info('preset_modes(): ' + str(self._preset_modes))
+        # get the list of available preset modes
+        return self._preset_modes
+
+    @property
     def hvac_modes(self):
         _LOGGER.info('hvac_modes(): ' + str(self._hvac_modes))
         # Return the list of available operation modes.
@@ -782,8 +805,13 @@ class GreeClimate(ClimateEntity):
     def supported_features(self):
         _LOGGER.info('supported_features(): ' + str(SUPPORT_FLAGS))
         # Return the list of supported features.
-        return SUPPORT_FLAGS        
- 
+        return SUPPORT_FLAGS
+
+    @property
+    def unique_id(self):
+        # Return unique_id
+        return self._unique_id
+
     def set_temperature(self, **kwargs):
         _LOGGER.info('set_temperature(): ' + str(kwargs.get(ATTR_TEMPERATURE)))
         # Set new target temperatures.
@@ -802,6 +830,15 @@ class GreeClimate(ClimateEntity):
             # do nothing if HVAC is switched off
             _LOGGER.info('SyncState with SwUpDn=' + str(swing_mode))
             self.SyncState({'SwUpDn': self._swing_modes.index(swing_mode)})
+            self.schedule_update_ha_state()
+
+    def set_preset_mode(self, swing_mode):
+        _LOGGER.info('Set preset mode(): ' + str(preset_mode))
+        # set the preset mode
+        if not (self._acOptions['Pow'] == 0):
+            # do nothing if HVAC is switched off
+            _LOGGER.info('SyncState with SwingLfRig=' + str(preset_mode))
+            self.SyncState({'SwingLfRig': self._preset_modes.index(preset_mode)})
             self.schedule_update_ha_state()
 
     def set_fan_mode(self, fan):
@@ -834,11 +871,12 @@ class GreeClimate(ClimateEntity):
         self.SyncState({'Pow': 1})
         self.schedule_update_ha_state()
 
+    def turn_off(self):
+        _LOGGER.info('turn_off(): ')
+        # Turn on.
+        self.SyncState({'Pow': 0})
+        self.schedule_update_ha_state()
+
     async def async_added_to_hass(self):
         _LOGGER.info('Gree climate device added to hass()')
         self.SyncState()
-
-    @property
-    def unique_id(self):
-        # Return unique_id
-        return self._unique_id

--- a/custom_components/gree/climate.py
+++ b/custom_components/gree/climate.py
@@ -832,7 +832,7 @@ class GreeClimate(ClimateEntity):
             self.SyncState({'SwUpDn': self._swing_modes.index(swing_mode)})
             self.schedule_update_ha_state()
 
-    def set_preset_mode(self, swing_mode):
+    def set_preset_mode(self, preset_mode):
         _LOGGER.info('Set preset mode(): ' + str(preset_mode))
         # set the preset mode
         if not (self._acOptions['Pow'] == 0):

--- a/custom_components/gree/climate.py
+++ b/custom_components/gree/climate.py
@@ -66,9 +66,10 @@ CONF_ENCRYPTION_KEY = 'encryption_key'
 CONF_UID = 'uid'
 CONF_AUTO_XFAN = 'auto_xfan'
 CONF_AUTO_LIGHT = 'auto_light'
+CONF_TARGET_TEMP = 'target_temp'
 
 DEFAULT_PORT = 7000
-DEFAULT_TIMEOUT = 1
+DEFAULT_TIMEOUT = 10
 DEFAULT_TARGET_TEMP_STEP = 1
 
 # from the remote control and gree app
@@ -100,7 +101,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_ENCRYPTION_KEY): cv.string,
     vol.Optional(CONF_UID): cv.positive_int,
     vol.Optional(CONF_AUTO_XFAN): cv.boolean,
-    vol.Optional(CONF_AUTO_LIGHT): cv.boolean
+    vol.Optional(CONF_AUTO_LIGHT): cv.boolean,
+    vol.Optional(CONF_TARGET_TEMP): cv.entity_id
 })
 
 async def async_setup_platform(hass, config, async_add_devices, discovery_info=None):
@@ -120,6 +122,7 @@ async def async_setup_platform(hass, config, async_add_devices, discovery_info=N
     sleep_entity_id = config.get(CONF_SLEEP)
     eightdegheat_entity_id = config.get(CONF_EIGHTDEGHEAT)
     air_entity_id = config.get(CONF_AIR)
+    target_temp_entity_id = config.get(CONF_TARGET_TEMP)
     hvac_modes = HVAC_MODES
     fan_modes = FAN_MODES
     swing_modes = SWING_MODES
@@ -132,11 +135,12 @@ async def async_setup_platform(hass, config, async_add_devices, discovery_info=N
     _LOGGER.info('Adding Gree climate device to hass')
 
     async_add_devices([
-        GreeClimate(hass, name, ip_addr, port, mac_addr, timeout, target_temp_step, temp_sensor_entity_id, lights_entity_id, xfan_entity_id, health_entity_id, powersave_entity_id, sleep_entity_id, eightdegheat_entity_id, air_entity_id, hvac_modes, fan_modes, swing_modes, preset_modes, auto_xfan, auto_light, encryption_key, uid)
+        GreeClimate(hass, name, ip_addr, port, mac_addr, timeout, target_temp_step, temp_sensor_entity_id, lights_entity_id, xfan_entity_id, health_entity_id, powersave_entity_id, sleep_entity_id, eightdegheat_entity_id, air_entity_id, target_temp_entity_id, hvac_modes, fan_modes, swing_modes, preset_modes, auto_xfan, auto_light, encryption_key, uid)
     ])
 
 class GreeClimate(ClimateEntity):
-    def __init__(self, hass, name, ip_addr, port, mac_addr, timeout, target_temp_step, temp_sensor_entity_id, lights_entity_id, xfan_entity_id, health_entity_id, powersave_entity_id, sleep_entity_id, eightdegheat_entity_id, air_entity_id, hvac_modes, fan_modes, swing_modes, preset_modes, auto_xfan, auto_light,encryption_key=None, uid=None):
+
+    def __init__(self, hass, name, ip_addr, port, mac_addr, timeout, target_temp_step, temp_sensor_entity_id, lights_entity_id, xfan_entity_id, health_entity_id, powersave_entity_id, sleep_entity_id, eightdegheat_entity_id, air_entity_id, target_temp_entity_id, hvac_modes, fan_modes, swing_modes, preset_modes, auto_xfan, auto_light,encryption_key=None, uid=None):
         _LOGGER.info('Initialize the GREE climate device')
         self.hass = hass
         self._name = name
@@ -158,6 +162,7 @@ class GreeClimate(ClimateEntity):
         self._sleep_entity_id = sleep_entity_id
         self._eightdegheat_entity_id = eightdegheat_entity_id
         self._air_entity_id = air_entity_id
+        self._target_temp_entity_id = target_temp_entity_id
 
         self._hvac_mode = None
         self._fan_mode = None
@@ -215,11 +220,6 @@ class GreeClimate(ClimateEntity):
                 _LOGGER.info('Setting up xfan entity: ' + str(xfan_entity_id))
                 async_track_state_change_event(
                     hass, xfan_entity_id, self._async_xfan_entity_state_changed)
-                
-        if xfan_entity_id:
-            _LOGGER.info('Setting up xfan entity: ' + str(xfan_entity_id))
-            async_track_state_change_event(
-                hass, xfan_entity_id, self._async_xfan_entity_state_changed)
 
         if health_entity_id:
             _LOGGER.info('Setting up health entity: ' + str(health_entity_id))
@@ -245,6 +245,11 @@ class GreeClimate(ClimateEntity):
             _LOGGER.info('Setting up air entity: ' + str(air_entity_id))
             async_track_state_change_event(
                 hass, air_entity_id, self._async_air_entity_state_changed)
+
+        if target_temp_entity_id:
+            _LOGGER.info('Setting up target temp entity: ' + str(target_temp_entity_id))
+            async_track_state_change_event(
+                hass, target_temp_entity_id, self._async_target_temp_entity_state_changed)
         
         self._unique_id = 'climate.gree_' + mac_addr.decode('utf-8').lower()
 
@@ -322,6 +327,12 @@ class GreeClimate(ClimateEntity):
             _LOGGER.info('HA target temp set according to HVAC state to 8℃ since 8℃ heating mode is active')
         else:
             self._target_temperature = self._acOptions['SetTem']
+            if self._target_temp_entity_id:
+                target_temp_state = self.hass.states.get(self._target_temp_entity_id)
+                if target_temp_state:
+                    attr = target_temp_state.attributes
+                    if self._target_temperature in range(MIN_TEMP, MAX_TEMP+1):
+                        self.hass.states.async_set(self._target_temp_entity_id, float(self._target_temperature), attr)
             _LOGGER.info('HA target temp set according to HVAC state to: ' + str(self._acOptions['SetTem']))
 
     def UpdateHAOptions(self):
@@ -500,12 +511,13 @@ class GreeClimate(ClimateEntity):
         entity_id = event.data["entity_id"]
         old_state = event.data["old_state"]
         new_state = event.data["new_state"]
-        _LOGGER.info('temp_sensor state changed | ' + str(entity_id) + ' from ' + str(old_state.state) + ' to ' + str(new_state.state))
+        s = str(old_state.state) if hasattr(old_state,'state') else "None"
+        _LOGGER.info('temp_sensor state changed | ' + str(entity_id) + ' from ' + s + ' to ' + str(new_state.state))
         # Handle temperature changes.
         if new_state is None:
             return
         self._async_update_current_temp(new_state)
-        return self.async_update_ha_state()
+        return self.schedule_update_ha_state(True)
         
     @callback
     def _async_update_current_temp(self, state):
@@ -540,7 +552,7 @@ class GreeClimate(ClimateEntity):
             # do nothing if state change is triggered due to Sync with HVAC
             return
         self._async_update_current_lights(new_state)
-        return self.async_update_ha_state()
+        return self.schedule_update_ha_state(True)
 
     @callback
     def _async_update_current_lights(self, state):
@@ -568,7 +580,7 @@ class GreeClimate(ClimateEntity):
             _LOGGER.info('Cant set xfan in %s mode' % str(self._hvac_mode))
             return
         self._async_update_current_xfan(new_state)
-        return self.async_update_ha_state()
+        return self.schedule_update_ha_state(True)
 
     @callback
     def _async_update_current_xfan(self, state):
@@ -592,7 +604,7 @@ class GreeClimate(ClimateEntity):
             # do nothing if state change is triggered due to Sync with HVAC
             return
         self._async_update_current_health(new_state)
-        return self.async_update_ha_state()
+        return self.schedule_update_ha_state(True)
 
     @callback
     def _async_update_current_health(self, state):
@@ -620,7 +632,7 @@ class GreeClimate(ClimateEntity):
             _LOGGER.info('Cant set powersave in %s mode' % str(self._hvac_mode))
             return
         self._async_update_current_powersave(new_state)
-        return self.async_update_ha_state()
+        return self.schedule_update_ha_state(True)
 
     @callback
     def _async_update_current_powersave(self, state):
@@ -649,7 +661,7 @@ class GreeClimate(ClimateEntity):
             _LOGGER.info('Cant set sleep in %s mode' % str(self._hvac_mode))
             return
         self._async_update_current_sleep(new_state)
-        return self.async_update_ha_state()
+        return self.schedule_update_ha_state(True)
 
     @callback
     def _async_update_current_sleep(self, state):
@@ -677,7 +689,7 @@ class GreeClimate(ClimateEntity):
             _LOGGER.info('Cant set 8℃ heat in %s mode' % str(self._hvac_mode))
             return
         self._async_update_current_eightdegheat(new_state)
-        return self.async_update_ha_state()
+        return self.schedule_update_ha_state(True)
 
     @callback
     def _async_update_current_eightdegheat(self, state):
@@ -701,7 +713,7 @@ class GreeClimate(ClimateEntity):
             # do nothing if state change is triggered due to Sync with HVAC
             return
         self._async_update_current_air(new_state)
-        return self.async_update_ha_state()
+        return self.schedule_update_ha_state(True)
 
     @callback
     def _async_update_current_air(self, state):
@@ -714,7 +726,27 @@ class GreeClimate(ClimateEntity):
             return
         _LOGGER.error('Unable to update from air_entity!')
 
+    def _async_target_temp_entity_state_changed(self, event: Event[EventStateChangedData]) -> None:
+        entity_id = event.data["entity_id"]
+        old_state = event.data["old_state"]
+        new_state = event.data["new_state"]
+        _LOGGER.info('target_temp_entity state changed | ' + str(entity_id) + ' from ' + str(old_state.state) + ' to ' + str(new_state.state))
+        if new_state is None:
+            return
+        if int(float(new_state.state)) is self._target_temperature:
+            # do nothing if state change is triggered due to Sync with HVAC
+            return
+        self._async_update_current_target_temp(new_state)
+        return self.schedule_update_ha_state(True)
 
+    @callback
+    def _async_update_current_target_temp(self, state):
+        s = int(float(state.state))
+        _LOGGER.info('Updating HVAC with changed target_temp_entity state | ' + str(s))
+        if (s >= MIN_TEMP) and (s <= MAX_TEMP):
+            self.SyncState({'SetTem': s})
+            return
+        _LOGGER.error('Unable to update from target_temp_entity!')
 
     @property
     def should_poll(self):
@@ -889,8 +921,7 @@ class GreeClimate(ClimateEntity):
                     c.update({'Lig': 1})
             if (hvac_mode == HVACMode.COOL) or (hvac_mode == HVACMode.DRY):
                 if self._auto_xfan:
-                    c.update({'Blo': 1})
-                    
+                    c.update({'Blo': 1})   
         self.SyncState(c)
         self.schedule_update_ha_state()
 
@@ -910,12 +941,6 @@ class GreeClimate(ClimateEntity):
         if self._auto_light:
             c.update({'Lig': 0})
         self.SyncState(c)
-        self.schedule_update_ha_state()
-
-    def turn_off(self):
-        _LOGGER.info('turn_off(): ')
-        # Turn on.
-        self.SyncState({'Pow': 0})
         self.schedule_update_ha_state()
 
     async def async_added_to_hass(self):

--- a/custom_components/gree/climate.py
+++ b/custom_components/gree/climate.py
@@ -13,18 +13,29 @@ import os.path
 import voluptuous as vol
 import homeassistant.helpers.config_validation as cv
 
-from homeassistant.components.climate import (ClimateEntity, PLATFORM_SCHEMA)
-
-from homeassistant.components.climate.const import (
-    HVAC_MODE_OFF, HVAC_MODE_AUTO, HVAC_MODE_COOL, HVAC_MODE_DRY,
-    HVAC_MODE_FAN_ONLY, HVAC_MODE_HEAT, SUPPORT_FAN_MODE,
-    SUPPORT_TARGET_TEMPERATURE, SUPPORT_SWING_MODE)
+from homeassistant.components.climate import (
+    ClimateEntity,
+    ClimateEntityFeature,
+    HVACMode,
+    PLATFORM_SCHEMA
+)
 
 from homeassistant.const import (
-    ATTR_UNIT_OF_MEASUREMENT, ATTR_TEMPERATURE, 
-    CONF_NAME, CONF_HOST, CONF_PORT, CONF_MAC, CONF_TIMEOUT, CONF_CUSTOMIZE, 
-    STATE_ON, STATE_OFF, STATE_UNKNOWN, 
-    TEMP_CELSIUS, PRECISION_WHOLE, PRECISION_TENTHS)
+    ATTR_TEMPERATURE, 
+    ATTR_UNIT_OF_MEASUREMENT,
+    CONF_CUSTOMIZE,
+    CONF_HOST,
+    CONF_MAC,
+    CONF_NAME,
+    CONF_PORT,
+    CONF_TIMEOUT,
+    PRECISION_TENTHS,
+    PRECISION_WHOLE,
+    STATE_OFF, 
+    STATE_ON,
+    STATE_UNKNOWN,
+    UnitOfTemperature
+)
 
 from homeassistant.helpers.event import (async_track_state_change)
 from homeassistant.core import callback
@@ -38,7 +49,7 @@ REQUIREMENTS = ['pycryptodome']
 
 _LOGGER = logging.getLogger(__name__)
 
-SUPPORT_FLAGS = SUPPORT_TARGET_TEMPERATURE | SUPPORT_FAN_MODE | SUPPORT_SWING_MODE
+SUPPORT_FLAGS = ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.FAN_MODE | ClimateEntityFeature.SWING_MODE
 
 DEFAULT_NAME = 'Gree Climate'
 
@@ -63,7 +74,7 @@ MIN_TEMP = 16
 MAX_TEMP = 30
 
 # fixed values in gree mode lists
-HVAC_MODES = [HVAC_MODE_AUTO, HVAC_MODE_COOL, HVAC_MODE_DRY, HVAC_MODE_FAN_ONLY, HVAC_MODE_HEAT, HVAC_MODE_OFF]
+HVAC_MODES = [HVACMode.AUTO, HVACMode.COOL, HVACMode.DRY, HVACMode.FAN_ONLY, HVACMode.HEAT, HVACMode.OFF]
 
 FAN_MODES = ['Auto', 'Low', 'Medium-Low', 'Medium', 'Medium-High', 'High', 'Turbo', 'Quiet']
 SWING_MODES = ['Default', 'Swing in full range', 'Fixed in the upmost position', 'Fixed in the middle-up position', 'Fixed in the middle position', 'Fixed in the middle-low position', 'Fixed in the lowest position', 'Swing in the downmost region', 'Swing in the middle-low region', 'Swing in the middle region', 'Swing in the middle-up region', 'Swing in the upmost region']
@@ -398,7 +409,7 @@ class GreeClimate(ClimateEntity):
     def UpdateHAHvacMode(self):
         # Sync current HVAC operation mode to HA
         if (self._acOptions['Pow'] == 0):
-            self._hvac_mode = HVAC_MODE_OFF
+            self._hvac_mode = HVACMode.OFF
         else:
             self._hvac_mode = self._hvac_modes[self._acOptions['Mod']]
         _LOGGER.info('HA operation mode set according to HVAC state to: ' + str(self._hvac_mode))
@@ -515,7 +526,7 @@ class GreeClimate(ClimateEntity):
         if new_state.state is self._current_xfan:
             # do nothing if state change is triggered due to Sync with HVAC
             return
-        if not self._hvac_mode in (HVAC_MODE_COOL, HVAC_MODE_DRY):
+        if not self._hvac_mode in (HVACMode.COOL, HVACMode.DRY):
             # do nothing if not in cool or dry mode
             _LOGGER.info('Cant set xfan in %s mode' % str(self._hvac_mode))
             return
@@ -561,7 +572,7 @@ class GreeClimate(ClimateEntity):
         if new_state.state is self._current_powersave:
             # do nothing if state change is triggered due to Sync with HVAC
             return
-        if not self._hvac_mode in (HVAC_MODE_COOL):
+        if not self._hvac_mode in (HVACMode.COOL):
             # do nothing if not in cool mode
             _LOGGER.info('Cant set powersave in %s mode' % str(self._hvac_mode))
             return
@@ -587,7 +598,7 @@ class GreeClimate(ClimateEntity):
         if new_state.state is self._current_sleep:
             # do nothing if state change is triggered due to Sync with HVAC
             return
-        if not self._hvac_mode in (HVAC_MODE_COOL, HVAC_MODE_HEAT):
+        if not self._hvac_mode in (HVACMode.COOL, HVACMode.HEAT):
             # do nothing if not in cool or heat mode
             _LOGGER.info('Cant set sleep in %s mode' % str(self._hvac_mode))
             return
@@ -612,7 +623,7 @@ class GreeClimate(ClimateEntity):
         if new_state.state is self._current_eightdegheat:
             # do nothing if state change is triggered due to Sync with HVAC
             return
-        if not self._hvac_mode in (HVAC_MODE_HEAT):
+        if not self._hvac_mode in (HVACMode.HEAT):
             # do nothing if not in heat mode
             _LOGGER.info('Cant set 8℃ heat in %s mode' % str(self._hvac_mode))
             return
@@ -786,7 +797,7 @@ class GreeClimate(ClimateEntity):
     def set_hvac_mode(self, hvac_mode):
         _LOGGER.info('set_hvac_mode(): ' + str(hvac_mode))
         # Set new operation mode.
-        if (hvac_mode == HVAC_MODE_OFF):
+        if (hvac_mode == HVACMode.OFF):
             self.SyncState({'Pow': 0})
         else:
             self.SyncState({'Mod': self._hvac_modes.index(hvac_mode), 'Pow': 1})

--- a/custom_components/gree/climate.py
+++ b/custom_components/gree/climate.py
@@ -78,6 +78,7 @@ HVAC_MODES = [HVACMode.AUTO, HVACMode.COOL, HVACMode.DRY, HVACMode.FAN_ONLY, HVA
 
 FAN_MODES = ['Auto', 'Low', 'Medium-Low', 'Medium', 'Medium-High', 'High', 'Turbo', 'Quiet']
 SWING_MODES = ['Default', 'Swing in full range', 'Fixed in the upmost position', 'Fixed in the middle-up position', 'Fixed in the middle position', 'Fixed in the middle-low position', 'Fixed in the lowest position', 'Swing in the downmost region', 'Swing in the middle-low region', 'Swing in the middle region', 'Swing in the middle-up region', 'Swing in the upmost region']
+PRESET_MODES = ['Default', 'Full swing', 'Fixed in the leftmost position', 'Fixed in the middleleft position', 'Fixed in the middle postion','Fixed in the middleright position', 'Fixed in the rightmost position']
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,


### PR DESCRIPTION
Added support for auto_light:
- when set auto_light: true in config unit will always turn light on when power on and turn light light off when power off. Light entity id should be set but is optional and can be used to control light for example in sleep mode

Added support for auto_xfan:
- when set auto_xfan: true in config unit will always turn on xFan in cool and dry mode. There is no need to set xfan entity id, even if it is set, it will be ignored

Added support for target temperature entity id
- when set target_temp: input_number... in config we can control target temperature with input_number helper. 
Useful when someone wants to build a custom layout, for example with custom:button_card. Input number should be declared with attributes min: 16 max: 30

Updated async_update_ha_state() with async_schedule_update_ha(True)