### PR TITLE
Update unit of measurement within integration

### DIFF
--- a/custom_components/gree/climate.py
+++ b/custom_components/gree/climate.py
@@ -157,7 +157,7 @@ class GreeClimate(ClimateEntity):
 
         self._target_temperature = None
         self._target_temperature_step = target_temp_step
-        self._unit_of_measurement = hass.config.units.temperature_unit
+        self._unit_of_measurement = '°C'
         
         self._current_temperature = None
         self._temp_sensor_entity_id = temp_sensor_entity_id


### PR DESCRIPTION
Sets the unit within the integration to Celsius. The API sends/expects inputs as Celsius regardless of config state on the device. HA will translate the received temperatures according to the global units configuration.

This does NOT address the apparent jumps during updates to the temperature via the integration. As a guess, it's because the target_temp_step is also in Celsius (+/- 1°C).