### PR TITLE
Up-to-date version in manifest.json

### DIFF
--- a/custom_components/gree/manifest.json
+++ b/custom_components/gree/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "gree",
   "name": "Gree A/C",
-  "version": "2.3.1",
+  "version": "2.14.2",
   "documentation": "https://github.com/RobHofmann/HomeAssistant-GreeClimateComponent",
   "dependencies": [],
   "codeowners": ["@robhofmann"],


### PR DESCRIPTION
Hi,

It is not always clear what exactly version you are using in HACS, as it always has 2.3.1 since that vesion.
Just reinstalled this component several times until realized the actual version is not 2.3.1, but 2.14.2.
I believe it's a good practive to always align version of release with version in manifest.json :)

Regards,
Dmitry
