### PR TITLE
Fix horizontal swing bool / entity

### DIFF
--- a/custom_components/gree/climate.py
+++ b/custom_components/gree/climate.py
@@ -107,7 +107,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_AUTO_LIGHT): cv.entity_id,
     vol.Optional(CONF_TARGET_TEMP): cv.entity_id,
     vol.Optional(CONF_ENCRYPTION_VERSION, default=1): cv.positive_int,
-    vol.Optional(CONF_HORIZONTAL_SWING, default=False): cv.boolean,
+    vol.Optional(CONF_HORIZONTAL_SWING, default=False): cv.entity_id,
     vol.Optional(CONF_ANTI_DIRECT_BLOW): cv.entity_id,
     vol.Optional(CONF_DISABLE_AVAILABLE_CHECK, default=False): cv.boolean,
     vol.Optional(CONF_MAX_ONLINE_ATTEMPTS, default=3): cv.positive_int,


### PR DESCRIPTION
This looks like a bug, when configuring, I get: 

```
2025-04-03 12:34:47.986 ERROR (MainThread) [homeassistant.config] Invalid config for 'climate' from integration 'gree' at packages/climate/devices-ac.yaml, line 94: invalid boolean value input_boolean.horizontal_swing_klima for dictionary value 'horizontal_swing', got 'input_boolean.horizontal_swing_klima', please check the docs at https://github.com/RobHofmann/HomeAssistant-GreeClimateComponent
```