### PR TITLE
Fix empty roomtemp and alignment of temp units to match HA configuration

### DIFF
--- a/custom_components/gree/climate.py
+++ b/custom_components/gree/climate.py
@@ -652,7 +652,7 @@ class GreeClimate(ClimateEntity):
     def SyncState(self, acOptions = {}):
         #Fetch current settings from HVAC
         _LOGGER.info('Starting SyncState')
-
+        # Attempt to get the device ambient temp when temp_sensor in climate.yaml is not set 
         if not self._temp_sensor_entity_id:
             if self._has_temp_sensor is None:
                 _LOGGER.info('Attempt to check whether device has an built-in temperature sensor')

--- a/custom_components/gree/climate.py
+++ b/custom_components/gree/climate.py
@@ -561,32 +561,6 @@ class GreeClimate(ClimateEntity):
                         self.hass.states.async_set(self._anti_direct_blow_entity_id, self._current_anti_direct_blow, attr)
             _LOGGER.info('HA anti direct blow option set according to HVAC state to: ' + str(self._current_anti_direct_blow))
 
-    def UpdateHAAmbientTemperature(self):
-        raw = self._acOptions.get('TemSen')
-        try:
-            raw = float(raw)
-        except (TypeError, ValueError):
-            _LOGGER.debug("Skipping TemSen update; invalid raw value: %s", raw)
-            return
-    
-        # Gree reports TemSen = actual°C + 40
-        temp_c = raw - TEMP_OFFSET
-    
-        # If TemUn == 1, convert to °F; otherwise stay in °C
-        if int(self._acOptions.get('TemUn', 0)):
-            temp = temp_c * 9.0/5.0 + 32.0
-            unit = '°F'
-        else:
-            temp = temp_c
-            unit = '°C'
-    
-        self._current_temperature = temp
-        self._unit_of_measurement = unit
-    
-        _LOGGER.info(
-            f"HA current temperature set via TemSen={raw} → {temp:.1f}{unit}"
-        )
-    
     def UpdateHAHvacMode(self):
         # Sync current HVAC operation mode to HA
         if (self._acOptions['Pow'] == 0):
@@ -615,6 +589,32 @@ class GreeClimate(ClimateEntity):
             self._fan_mode = self._fan_modes[int(self._acOptions['WdSpd'])]
         _LOGGER.info('HA fan mode set according to HVAC state to: ' + str(self._fan_mode))
 
+    def UpdateHAAmbientTemperature(self):
+        raw = self._acOptions.get('TemSen')
+        try:
+            raw = float(raw)
+        except (TypeError, ValueError):
+            _LOGGER.debug("Skipping TemSen update; invalid raw value: %s", raw)
+            return
+    
+        # Gree reports TemSen = actual°C + 40
+        temp_c = raw - TEMP_OFFSET
+    
+        # If TemUn == 1, convert to °F; otherwise stay in °C
+        if int(self._acOptions.get('TemUn', 0)):
+            temp = temp_c * 9.0/5.0 + 32.0
+            unit = '°F'
+        else:
+            temp = temp_c
+            unit = '°C'
+    
+        self._current_temperature = temp
+        self._unit_of_measurement = unit
+    
+        _LOGGER.info(
+            f"HA current temperature set via TemSen={raw} → {temp:.1f}{unit}"
+        )
+        
     def UpdateTargetTemperature(self):
         # pick up the remote’s unit flag
         unit_flag = int(self._acOptions.get('TemUn', 0))
@@ -734,13 +734,6 @@ class GreeClimate(ClimateEntity):
             # Overwrite status with our choices
             if not(acOptions == {}):
                 self._acOptions = self.SetAcOptions(self._acOptions, acOptions)
-            # Dynamic temperature unit detection based on TemUn
-            unit_code = self._acOptions.get('TemUn', 0)
-            if unit_code == 1:
-                self._unit_of_measurement = '°F'
-            else:
-                self._unit_of_measurement = '°C'
-            _LOGGER.info('Using TemUn=%s → display unit %s', unit_code, self._unit_of_measurement)
 
             # Initialize the receivedJsonPayload variable (for return)
             receivedJsonPayload = ''

--- a/custom_components/gree/climate.py
+++ b/custom_components/gree/climate.py
@@ -614,7 +614,7 @@ class GreeClimate(ClimateEntity):
         _LOGGER.info(
             f"HA current temperature set via TemSen={raw} → {temp:.1f}{unit}"
         )
-        
+
     def UpdateTargetTemperature(self):
         # pick up the remote’s unit flag
         unit_flag = int(self._acOptions.get('TemUn', 0))
@@ -644,9 +644,9 @@ class GreeClimate(ClimateEntity):
         if self._horizontal_swing:
             self.UpdateHACurrentPresetMode()
         self.UpdateHAFanMode()
-        self.UpdateTargetTemperature()
         if not self._temp_sensor_entity_id:
             self.UpdateHAAmbientTemperature()
+        self.UpdateTargetTemperature()
         
 
     def SyncState(self, acOptions = {}):


### PR DESCRIPTION
- Renamed UpdateHACurrentTemperature to UpdateHAAmbientTemperature for better clarity 
- Added helper method UpdateTargetTemperature 
-- Ensures any adjusted target temps set are reflected in HA with conversion when appropriate 
- Conditionally run 'self.UpdateHAAmbientTemperature()' dependent on whether an external sensor is present or not 
-  Refactored '_async_update_current_temp' 
-- Consistency between HA and the Tosot/Gree unit of temp measurement 

Tested with my Tosot minisplit unit 
HA Units: F 
Tosot units tested in both C and F
Display in my HA was updated to F when the tosot/gree unit was in C.  Setting temps in F was still possible without changing the aircon's unit of measurement. 


