### PR TITLE
Fixed ambient temperature display and temperature set in F 

### DIFF
--- a/custom_components/gree/climate.py
+++ b/custom_components/gree/climate.py
@@ -171,6 +171,7 @@ class GreeClimate(ClimateEntity):
 
         self._target_temperature = None
         self._target_temperature_step = target_temp_step
+        self._native_unit_of_measurement = '°C'
         self._unit_of_measurement = '°C'
 
         self._hvac_modes = hvac_modes
@@ -589,52 +590,16 @@ class GreeClimate(ClimateEntity):
             self._fan_mode = self._fan_modes[int(self._acOptions['WdSpd'])]
         _LOGGER.info('HA fan mode set according to HVAC state to: ' + str(self._fan_mode))
 
-    def UpdateHAAmbientTemperature(self):
-        raw = self._acOptions.get('TemSen')
-        try:
-            raw = float(raw)
-        except (TypeError, ValueError):
-            _LOGGER.debug("Skipping TemSen update; invalid raw value: %s", raw)
-            return
-    
-        # Gree reports TemSen = actual°C + 40
-        temp_c = raw - TEMP_OFFSET
-    
-        # If TemUn == 1, convert to °F; otherwise stay in °C
-        if int(self._acOptions.get('TemUn', 0)):
-            temp = temp_c * 9.0/5.0 + 32.0
-            unit = '°F'
-        else:
-            temp = temp_c
-            unit = '°C'
-    
-        self._current_temperature = temp
-        self._unit_of_measurement = unit
-    
-        _LOGGER.info(
-            f"HA current temperature set via TemSen={raw} → {temp:.1f}{unit}"
-        )
-        
-    def UpdateTargetTemperature(self):
-        # pick up the remote’s unit flag
-        unit_flag = int(self._acOptions.get('TemUn', 0))
-        raw = float(self._acOptions['SetTem'])
-
-        if unit_flag == 1:
-            # AC is in “Fahrenheit mode” → raw is actually in °C, so convert
-            self._target_temperature = raw * 9.0/5.0 + 32.0
-            self._unit_of_measurement = '°F'
-        else:
-            # AC in “Celsius mode”
-            self._target_temperature = raw
-            self._unit_of_measurement = '°C'
-
-        _LOGGER.info(
-            'HA target temperature set using TemUn=%s → %s%s',
-            unit_flag,
-            round(self._target_temperature,1),
-            self._unit_of_measurement
-        )
+    def UpdateHACurrentTemperature(self):
+        if not self._temp_sensor_entity_id:
+            if self._has_temp_sensor:          
+                temp = self._acOptions['TemSen'] if self._acOptions['TemSen'] <= TEMP_OFFSET else self._acOptions['TemSen'] - TEMP_OFFSET
+                if int(self._acOptions.get('TemUn', 0)):
+                    self._unit_of_measurement = '°F'
+                else:
+                    self._unit_of_measurement = '°C'
+                self._current_temperature = self.hass.config.units.temperature(float(temp), self._unit_of_measurement)
+                _LOGGER.info('HA current temperature set with device built-in temperature sensor state : ' + str(self._current_temperature))
 
     def UpdateHAStateToCurrentACState(self):
         self.UpdateHATargetTemperature()
@@ -644,15 +609,13 @@ class GreeClimate(ClimateEntity):
         if self._horizontal_swing:
             self.UpdateHACurrentPresetMode()
         self.UpdateHAFanMode()
-        if not self._temp_sensor_entity_id:
-            self.UpdateHAAmbientTemperature()
-        self.UpdateTargetTemperature()
+        self.UpdateHACurrentTemperature()
         
 
     def SyncState(self, acOptions = {}):
         #Fetch current settings from HVAC
         _LOGGER.info('Starting SyncState')
-        # Attempt to get the device ambient temp when temp_sensor in climate.yaml is not set 
+
         if not self._temp_sensor_entity_id:
             if self._has_temp_sensor is None:
                 _LOGGER.info('Attempt to check whether device has an built-in temperature sensor')
@@ -723,13 +686,6 @@ class GreeClimate(ClimateEntity):
                     self._online_attempts = 0
             # Set latest status from device
             self._acOptions = self.SetAcOptions(self._acOptions, optionsToFetch, currentValues)
-            # Dynamic temperature unit detection based on TemUn
-            unit_code = self._acOptions.get('TemUn', 0)
-            if unit_code == 1:
-                self._unit_of_measurement = '°F'
-            else:
-                self._unit_of_measurement = '°C'
-            _LOGGER.info('Using TemUn=%s → display unit %s', unit_code, self._unit_of_measurement)
 
             # Overwrite status with our choices
             if not(acOptions == {}):
@@ -767,37 +723,17 @@ class GreeClimate(ClimateEntity):
         
     @callback
     def _async_update_current_temp(self, state):
-        _LOGGER.info('Thermostat external sensor update | %s', state.state)
-        raw = state.state
-        if not self.represents_float(raw):
-            _LOGGER.debug('Temp sensor state "%s" is not numeric. Ignoring.', raw)
-            return
-
+        _LOGGER.info('Thermostat updated with changed temp_sensor state | ' + str(state.state))
+        unit = state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
         try:
-            val = float(raw)
+            _state = state.state
+            _LOGGER.info('Current state temp_sensor: ' + _state)
+            if self.represents_float(_state):
+                self._current_temperature = self.hass.config.units.temperature(
+                    float(_state), unit)
+                _LOGGER.info('Current temp: ' + str(self._current_temperature))
         except ValueError as ex:
-            _LOGGER.error('Unable to parse temp_sensor state: %s', ex)
-            return
-
-        # What unit the sensor is reporting (°C or °F)
-        sensor_unit = state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
-
-        # Convert into the climate entity's unit (self.temperature_unit)
-        # so that it always matches the user's HA settings.
-        self._current_temperature = self.hass.config.units.temperature(
-            val, sensor_unit
-        )
-        # Make sure the climate entity reports its own unit
-        self._unit_of_measurement = self.temperature_unit
-
-        _LOGGER.info(
-            'External sensor %s%s → converted to %s%s',
-            val,
-            sensor_unit or '',
-            self._current_temperature,
-            self._unit_of_measurement
-        )
-
+            _LOGGER.error('Unable to update from temp_sensor: %s' % ex)
 
     def represents_float(self, s):
         _LOGGER.info('temp_sensor state represents_float |' + str(s))
@@ -1206,9 +1142,9 @@ class GreeClimate(ClimateEntity):
 
     @property
     def temperature_unit(self):
-        _LOGGER.info('temperature_unit(): ' + str(self._unit_of_measurement))
+        _LOGGER.info('temperature_unit(): ' + str(self._native_unit_of_measurement))
         # Return the unit of measurement.
-        return self._unit_of_measurement
+        return self._native_unit_of_measurement
 
     @property
     def current_temperature(self):

--- a/custom_components/gree/climate.py
+++ b/custom_components/gree/climate.py
@@ -72,7 +72,7 @@ MIN_TEMP = 16
 MAX_TEMP = 30
 
 # update() interval
-SCAN_INTERVAL = timedelta(seconds=10)
+SCAN_INTERVAL = timedelta(seconds=60)
 
 TEMP_OFFSET  = 40
 

--- a/custom_components/gree/climate.py
+++ b/custom_components/gree/climate.py
@@ -170,7 +170,6 @@ class GreeClimate(ClimateEntity):
         self._disable_available_check = disable_available_check
 
         self._target_temperature = None
-        self._tem_rec = 0
         self._target_temperature_step = target_temp_step
 
         self._unit_of_measurement = '°C'
@@ -1177,12 +1176,6 @@ class GreeClimate(ClimateEntity):
         # Return the temperature we try to reach.
         return self._target_temperature
     
-    @property 
-    def tem_rec(self):
-        _LOGGER.info('tem_rec(): ' + str(self.tem_rec))
-        # Return the temperature we try to reach.
-        return self._tem_rec
-        
     @property
     def target_temperature_step(self):
         _LOGGER.info('target_temperature_step(): ' + str(self._target_temperature_step))
@@ -1268,10 +1261,10 @@ class GreeClimate(ClimateEntity):
                 # TempRec TemSet Mapping for setting Fahrenheit
                 # TemSet = round((desired_temp_f - 32.0) * 5.0 / 9.0)
                 # TemRec = (int) ((((desired_temp_f - 32.0) * 5.0 / 9.0) - TemSet) > 0)
-                self._tem_rec = 1 if (raw_c - int(round(raw_c)) ) > 0 else 0
-                self.SyncState({ 'SetTem': int(round(raw_c)), 'TemRec': self._tem_rec })
+                tem_rec = 1 if (raw_c - int(round(raw_c)) ) > 0 else 0
+                self.SyncState({ 'SetTem': int(round(raw_c)), 'TemRec': tem_rec })
                 _LOGGER.debug('method set_temperature SetTem=' + str(int(round(raw_c))) )
-                _LOGGER.debug('method set_temperature TemRec=' + str(self._tem_rec) )
+                _LOGGER.debug('method set_temperature TemRec=' + str(tem_rec) )
                 self.schedule_update_ha_state()
                 
 

--- a/custom_components/gree/climate.py
+++ b/custom_components/gree/climate.py
@@ -172,7 +172,7 @@ class GreeClimate(ClimateEntity):
         self._target_temperature = None
         self._tem_rec = 0
         self._target_temperature_step = target_temp_step
-        self._native_unit_of_measurement = '°C'
+
         self._unit_of_measurement = '°C'
 
         self._hvac_modes = hvac_modes
@@ -730,8 +730,8 @@ class GreeClimate(ClimateEntity):
             if self.represents_float(_state):
                 # Native unit of measurement for Tosot / Gree units is Celsius
                 # If the HA system is configured for Fahrenheit, convert to Celsius for accurate reading
-                if unit != self._native_unit_of_measurement:
-                    _LOGGER.debug('method _async_update_current_temp Converting temperature from %s to %s' % (unit, self._native_unit_of_measurement))
+                if unit != self._unit_of_measurement:
+                    _LOGGER.debug('method _async_update_current_temp Converting temperature from %s to %s' % (unit, self._unit_of_measurement))
                     self._current_temperature = (float(_state) - 32) * 5 / 9 
                     _LOGGER.debug('method _async_update_current_temp set ambient temp to: ' + str(self._current_temperature))
                 else:
@@ -1149,9 +1149,9 @@ class GreeClimate(ClimateEntity):
 
     @property
     def temperature_unit(self):
-        _LOGGER.info('temperature_unit(): ' + str(self._native_unit_of_measurement))
+        _LOGGER.info('temperature_unit(): ' + str(self._unit_of_measurement))
         # Return the unit of measurement.
-        return self._native_unit_of_measurement
+        return self._unit_of_measurement
 
     @property
     def current_temperature(self):


### PR DESCRIPTION
- Fixed temp adjustment for Fahrenheit.  
-- Temperatures set weren't being accurately reflected on the lovelace dashboard due to F to C rounding.  
-- TemRec: this bit is used to distinguish between two Fahrenheit values -> https://github.com/tomikaa87/gree-remote?tab=readme-ov-file
- Rolled back to last good commit prior to the two most recent PRs and added in the conversion from that commit which was working the best of the most recent edits. 
- Refrained from readjusting '_unit_of_measurement' in down level methods and instead converted values where appropriate.  -- Much simpler to debug and manage  
