### PR TITLE
Rework and Improvement of Fahrenheit Conversion

### DIFF
--- a/custom_components/gree/manifest.json
+++ b/custom_components/gree/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "gree",
   "name": "Gree A/C",
-  "version": "2.14.2",
+  "version": "2.15.3",
   "documentation": "https://github.com/RobHofmann/HomeAssistant-GreeClimateComponent",
   "dependencies": [],
   "codeowners": ["@robhofmann"],


### PR DESCRIPTION
I had Fahrenheit support coded up and tested last month, but got busy and wasn't able to get a PR made. It looks like [phirschorn](https://github.com/phirschorn) beat me to it! However, this update makes several notable improvements, simplifications, and bug fixes.

Most notably, I made the integration unit_aware (I know [phirschorn](https://github.com/phirschorn) tried a version of this), and fixed a bug with the HA UI display jumping around because of a need to convert to Fahrenheit from the **SetTem** and **TemRec** bits to display properly in HA. I also updated the version in the manifest.json.

**Summary:**
* Adds temperature awareness, but using HA units of measurement to determine SetTem and TemRec as well as display logic instead of temperature ranges (min_temp and max_temp). This is more accurate and robust.

* Properly updates the unit in both the asynchronous and set_temperature methods.

* Adds bi-directional temperature conversion functions. See details below.

* Converts the temperature FROM the gree to properly display in HA, instead of skipping some values in Fahrenheit. The conversion must be bidirectional due to the nature of the SetTem and TemRec bits. This fixes a bug where if you try to set a "intermediate" temperature with the TemRec bit set to 1, such as 78 F, the HA UI will jump to 79.