### PR TITLE
Determine TemSen temperature offset automatically or manually. (#246)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Tested on the following hardware:
 - Cooper & Hunter (CH-S12FTXE(WI-FI)-NG)
 - AC Pioneer Fortis Series with WI-FI module CS532AE
 - AC Gree GWH12ACC-K6DNA1D
+- AC Gree 3VIR24HP230V1AH
 - Inventor Life Pro WiFi
 - Toyotomi Izuru TRN/TRG-828ZR
 - Sinclair ASH-13BIF2
@@ -64,11 +65,12 @@ This component is added to HACS default repository list.
      target_temp: <OPTIONAL: input_number used to set the temperature of your first AC>
      auto_xfan: <OPTIONAL: input_boolean: this feature will always turn on xFan in cool and dry mode to avoid mold & rust created from potential water buildup in the AC>
      auto_light: <OPTIONAL: input_boolean: this feature will always turn light on when power on and turn light light off when power off automatically>
-     horizontal_swing: <OPTIONAL: boolean (true/false); this feature will enable horizontal swing on devices that have this functionality. This feature replaces presets in the UI
+     horizontal_swing: <OPTIONAL: boolean (true/false); this feature will enable horizontal swing on devices that have this functionality. This feature replaces presets in the UI>
      anti_direct_blow: <OPTIONAL: input_boolean used to switch Anti Direct Blow feature on devices devices that have this functionality. Until next release, it should be set only when device   has this feature. For example: input_boolean.first_ac_anti_direct_blow>
-     light_sensor: <OPTIONAL: input_boolean this feature will enable built-in light sensor. 
-     max_online_attempts: <OPTIONAL: integer specifying number of attempts to connect to the device before it goes into the unavailable state
-     disable_available_check: <OPTIONAL: boolean (true/false): if set to true device is always available in Home Assistant, useful for automation, device never goes into an unavailable state
+     light_sensor: <OPTIONAL: input_boolean this feature will enable built-in light sensor.>
+     max_online_attempts: <OPTIONAL: integer specifying number of attempts to connect to the device before it goes into the unavailable state>
+     disable_available_check: <OPTIONAL: boolean (true/false): if set to true device is always available in Home Assistant, useful for automation, device never goes into an unavailable state>
+     temp_sensor_offset: <OPTIONAL: boolean (true/false): if set to true, the temperature sensor in the device will be offset by -40C when displayed in HA. If set to false, no offset will be applied. If not set, the script will try to determine the offset automatically.>
 
    - platform: gree
      name: Second AC

--- a/climate.yaml
+++ b/climate.yaml
@@ -14,6 +14,7 @@
   sleep: <input_boolean used to switch sleep on/off of your first AC>
   powersave: <input_boolean used to switch powersave on/off of your first AC>
   eightdegheat: <input_boolean used to switch 8 degree heating on/off on your first AC>
+  temp_sensor_offset: <input_boolean for temperature sensor offset in first AC room>
 
 - platform: gree
   # required settings:

--- a/custom_components/gree/manifest.json
+++ b/custom_components/gree/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "gree",
   "name": "Gree A/C",
-  "version": "2.15.3",
+  "version": "2.15.4",
   "documentation": "https://github.com/RobHofmann/HomeAssistant-GreeClimateComponent",
   "dependencies": [],
   "codeowners": ["@robhofmann"],


### PR DESCRIPTION
According to this reference: https://github.com/tomikaa87/gree-remote/ TemSen is offset by +40. However, [tomikaa87/gree-remote#31](https://github.com/tomikaa87/gree-remote/issues/31) suggests that the newer firmware (> 4.0) does not include the offset. After some testing with multiple users, this is not always reliable. Automatically determining if the offset should be there based on the raw temperature value seemed a little hacky, so I added some more sophisticated logic. I think this is the best way and is going to work 99.9% of the time.

* Automatically determines if offset is appropriate. Uses historical min/max historical TemSen values to best determine offset.
* Added ability for users to manually set boolean for the if offset is applied. (This overwrites automatic determination).
* Updated climate.yaml and README.md with instructions for manual offset.
* Added Gree 3VIR24HP230V1AH to units tested.
* Minor bug fixes/syntax.