### PR TITLE
Add config flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ Tested on Home Assistant 2024.5.4.
 ## HACS
 This component is added to HACS default repository list.
 
+## UI Configuration
+The integration can be added from the Home Assistant UI.
+1. Navigate to **Settings** > **Devices & Services** and click **Add Integration**.
+2. Search for **Gree Climate** and fill in the host, port and MAC address.
+3. After setup you can open the integration options to configure additional parameters.
+
 ## Custom Component Installation
 !!! PLEASE NOTE !!!: Skip step 1 if you are using HACS.
 

--- a/custom_components/gree/__init__.py
+++ b/custom_components/gree/__init__.py
@@ -1,0 +1,32 @@
+"""Gree climate integration init."""
+
+from __future__ import annotations
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.typing import ConfigType
+
+from .const import DOMAIN, PLATFORMS
+
+
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Set up the Gree component from yaml."""
+    return True
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up Gree from a config entry."""
+    if DOMAIN not in hass.data:
+        hass.data[DOMAIN] = {}
+
+    hass.data[DOMAIN][entry.entry_id] = entry.data
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    unloaded = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    if unloaded:
+        hass.data[DOMAIN].pop(entry.entry_id)
+    return unloaded

--- a/custom_components/gree/config_flow.py
+++ b/custom_components/gree/config_flow.py
@@ -1,0 +1,117 @@
+"""Config flow for Gree climate integration."""
+
+from __future__ import annotations
+
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.const import (
+    CONF_HOST,
+    CONF_MAC,
+    CONF_NAME,
+    CONF_PORT,
+    CONF_TIMEOUT,
+)
+from homeassistant.data_entry_flow import FlowResult
+
+from .const import DOMAIN
+from .climate import (
+    DEFAULT_PORT,
+    DEFAULT_TIMEOUT,
+    DEFAULT_TARGET_TEMP_STEP,
+    CONF_TARGET_TEMP_STEP,
+    CONF_TEMP_SENSOR,
+    CONF_LIGHTS,
+    CONF_XFAN,
+    CONF_HEALTH,
+    CONF_POWERSAVE,
+    CONF_SLEEP,
+    CONF_EIGHTDEGHEAT,
+    CONF_AIR,
+    CONF_ENCRYPTION_KEY,
+    CONF_UID,
+    CONF_AUTO_XFAN,
+    CONF_AUTO_LIGHT,
+    CONF_TARGET_TEMP,
+    CONF_HORIZONTAL_SWING,
+    CONF_ANTI_DIRECT_BLOW,
+    CONF_ENCRYPTION_VERSION,
+    CONF_DISABLE_AVAILABLE_CHECK,
+    CONF_MAX_ONLINE_ATTEMPTS,
+    CONF_LIGHT_SENSOR,
+    CONF_TEMP_SENSOR_OFFSET,
+    CONF_LANGUAGE,
+)
+
+
+class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Gree climate."""
+
+    VERSION = 1
+
+    def __init__(self) -> None:
+        self._data: dict[str, any] = {}
+
+    async def async_step_user(self, user_input: dict | None = None) -> FlowResult:
+        """Handle the initial step."""
+        if user_input is not None:
+            self._data.update(user_input)
+            return self.async_create_entry(title=user_input.get(CONF_NAME) or "Gree Climate", data=self._data)
+
+        data_schema = vol.Schema(
+            {
+                vol.Required(CONF_HOST): str,
+                vol.Required(CONF_MAC): str,
+                vol.Required(CONF_PORT, default=DEFAULT_PORT): int,
+                vol.Optional(CONF_NAME): str,
+                vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): int,
+                vol.Optional(CONF_ENCRYPTION_KEY): str,
+                vol.Optional(CONF_UID): int,
+                vol.Optional(CONF_ENCRYPTION_VERSION, default=1): int,
+            }
+        )
+        return self.async_show_form(step_id="user", data_schema=data_schema)
+
+    async def async_step_import(self, import_data: dict) -> FlowResult:
+        """Handle configuration via YAML import."""
+        return await self.async_step_user(import_data)
+
+    async def async_get_options_flow(self, config_entry: config_entries.ConfigEntry) -> config_entries.OptionsFlow:
+        return OptionsFlowHandler(config_entry)
+
+
+class OptionsFlowHandler(config_entries.OptionsFlow):
+    """Handle an options flow for Gree climate."""
+
+    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
+        self.config_entry = config_entry
+
+    async def async_step_init(self, user_input: dict | None = None) -> FlowResult:
+        if user_input is not None:
+            return self.async_create_entry(title="", data=user_input)
+
+        options = {**self.config_entry.options}
+        schema = vol.Schema(
+            {
+                vol.Optional(CONF_TARGET_TEMP_STEP, default=options.get(CONF_TARGET_TEMP_STEP, DEFAULT_TARGET_TEMP_STEP)): vol.Coerce(float),
+                vol.Optional(CONF_TEMP_SENSOR, default=options.get(CONF_TEMP_SENSOR)): str,
+                vol.Optional(CONF_LIGHTS, default=options.get(CONF_LIGHTS)): str,
+                vol.Optional(CONF_XFAN, default=options.get(CONF_XFAN)): str,
+                vol.Optional(CONF_HEALTH, default=options.get(CONF_HEALTH)): str,
+                vol.Optional(CONF_POWERSAVE, default=options.get(CONF_POWERSAVE)): str,
+                vol.Optional(CONF_SLEEP, default=options.get(CONF_SLEEP)): str,
+                vol.Optional(CONF_EIGHTDEGHEAT, default=options.get(CONF_EIGHTDEGHEAT)): str,
+                vol.Optional(CONF_AIR, default=options.get(CONF_AIR)): str,
+                vol.Optional(CONF_TARGET_TEMP, default=options.get(CONF_TARGET_TEMP)): str,
+                vol.Optional(CONF_AUTO_XFAN, default=options.get(CONF_AUTO_XFAN)): str,
+                vol.Optional(CONF_AUTO_LIGHT, default=options.get(CONF_AUTO_LIGHT)): str,
+                vol.Optional(CONF_HORIZONTAL_SWING, default=options.get(CONF_HORIZONTAL_SWING, False)): bool,
+                vol.Optional(CONF_ANTI_DIRECT_BLOW, default=options.get(CONF_ANTI_DIRECT_BLOW)): str,
+                vol.Optional(CONF_DISABLE_AVAILABLE_CHECK, default=options.get(CONF_DISABLE_AVAILABLE_CHECK, False)): bool,
+                vol.Optional(CONF_MAX_ONLINE_ATTEMPTS, default=options.get(CONF_MAX_ONLINE_ATTEMPTS, 3)): int,
+                vol.Optional(CONF_LIGHT_SENSOR, default=options.get(CONF_LIGHT_SENSOR)): str,
+                vol.Optional(CONF_TEMP_SENSOR_OFFSET, default=options.get(CONF_TEMP_SENSOR_OFFSET)): bool,
+                vol.Optional(CONF_LANGUAGE, default=options.get(CONF_LANGUAGE)): str,
+            }
+        )
+        return self.async_show_form(step_id="init", data_schema=schema)

--- a/custom_components/gree/const.py
+++ b/custom_components/gree/const.py
@@ -1,0 +1,2 @@
+DOMAIN = "gree"
+PLATFORMS = ["climate"]

--- a/custom_components/gree/manifest.json
+++ b/custom_components/gree/manifest.json
@@ -4,6 +4,12 @@
   "version": "2.16.0",
   "documentation": "https://github.com/RobHofmann/HomeAssistant-GreeClimateComponent",
   "dependencies": [],
-  "codeowners": ["@robhofmann"],
-  "requirements": ["pycryptodome", "aiofiles"]
+  "codeowners": [
+    "@robhofmann"
+  ],
+  "requirements": [
+    "pycryptodome",
+    "aiofiles"
+  ],
+  "config_flow": true
 }

--- a/custom_components/gree/translations/en.json
+++ b/custom_components/gree/translations/en.json
@@ -2,6 +2,20 @@
   "config": {
     "title": "Gree Climate",
     "description": "Configure your Gree air conditioner",
+    "step": {
+      "user": {
+        "data": {
+          "name": "Name",
+          "host": "IP Address",
+          "port": "Port",
+          "mac": "MAC Address",
+          "timeout": "Timeout",
+          "encryption_key": "Encryption Key",
+          "uid": "UID",
+          "encryption_version": "Encryption Version"
+        }
+      }
+    },
     "data": {
       "name": "Name",
       "host": "IP Address",
@@ -29,6 +43,34 @@
       "disable_available_check": "Disable Available Check",
       "max_online_attempts": "Max Online Attempts",
       "temp_sensor_offset": "Temperature Sensor Offset"
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Gree Climate Options",
+        "data": {
+          "target_temp_step": "Temperature Step",
+          "temp_sensor": "Temperature Sensor",
+          "lights": "Lights Entity",
+          "xfan": "X-Fan Entity",
+          "health": "Health Entity",
+          "powersave": "Power Save Entity",
+          "sleep": "Sleep Entity",
+          "eightdegheat": "8°C Heat Entity",
+          "air": "Air Entity",
+          "target_temp": "Target Temperature Entity",
+          "auto_xfan": "Auto X-Fan Entity",
+          "auto_light": "Auto Light Entity",
+          "horizontal_swing": "Horizontal Swing",
+          "anti_direct_blow": "Anti Direct Blow Entity",
+          "disable_available_check": "Disable Available Check",
+          "max_online_attempts": "Max Online Attempts",
+          "light_sensor": "Light Sensor Entity",
+          "temp_sensor_offset": "Temperature Sensor Offset",
+          "language": "Language"
+        }
+      }
     }
   },
   "entity": {

--- a/custom_components/gree/translations/ru.json
+++ b/custom_components/gree/translations/ru.json
@@ -2,6 +2,20 @@
   "config": {
     "title": "Gree Климат",
     "description": "Настройка вашего кондиционера Gree",
+    "step": {
+      "user": {
+        "data": {
+          "name": "Название",
+          "host": "IP-адрес",
+          "port": "Порт",
+          "mac": "MAC-адрес",
+          "timeout": "Таймаут",
+          "encryption_key": "Ключ шифрования",
+          "uid": "UID",
+          "encryption_version": "Версия шифрования"
+        }
+      }
+    },
     "data": {
       "name": "Название",
       "host": "IP-адрес",
@@ -29,6 +43,34 @@
       "disable_available_check": "Отключить проверку доступности",
       "max_online_attempts": "Максимум попыток подключения",
       "temp_sensor_offset": "Смещение датчика температуры"
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Настройки Gree Климат",
+        "data": {
+          "target_temp_step": "Шаг температуры",
+          "temp_sensor": "Датчик температуры",
+          "lights": "Объект освещения",
+          "xfan": "Объект X-Fan",
+          "health": "Объект здоровья",
+          "powersave": "Объект энергосбережения",
+          "sleep": "Объект сна",
+          "eightdegheat": "Объект нагрева 8°C",
+          "air": "Объект воздуха",
+          "target_temp": "Объект целевой температуры",
+          "auto_xfan": "Объект авто X-Fan",
+          "auto_light": "Объект авто освещения",
+          "horizontal_swing": "Горизонтальные жалюзи",
+          "anti_direct_blow": "Объект защиты от прямого потока",
+          "disable_available_check": "Отключить проверку доступности",
+          "max_online_attempts": "Максимум попыток подключения",
+          "light_sensor": "Объект датчика света",
+          "temp_sensor_offset": "Смещение датчика температуры",
+          "language": "Язык"
+        }
+      }
     }
   },
   "entity": {

--- a/info.md
+++ b/info.md
@@ -1,8 +1,11 @@
 # Custom Gree climate integration. Controls AC's supporting the Gree protocol.
 
-## Component configuration
+## UI Configuration
+You can add the integration from the Home Assistant UI.
+Navigate to **Settings** > **Devices & Services** and search for **Gree Climate**.
 
-To configure this component, add the following configuration to your configuration.yaml (replacing the placeholders).
+## Component configuration
+To configure this component manually, add the following configuration to your configuration.yaml (replacing the placeholders).
 
 ```
  climate:


### PR DESCRIPTION
## Summary
- implement ConfigFlow and OptionsFlow
- support config entries in `__init__.py`
- enable config flow in manifest
- update translations for new flow
- document UI setup steps

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68407370f75c8321b4780fca1594fab9