### PR TITLE
Fix config options validation

### DIFF
--- a/custom_components/gree/config_flow.py
+++ b/custom_components/gree/config_flow.py
@@ -96,25 +96,68 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         options = {**self.config_entry.options}
         schema = vol.Schema(
             {
-                vol.Optional(CONF_TARGET_TEMP_STEP, default=options.get(CONF_TARGET_TEMP_STEP, DEFAULT_TARGET_TEMP_STEP)): vol.Coerce(float),
-                vol.Optional(CONF_TEMP_SENSOR, default=options.get(CONF_TEMP_SENSOR)): str,
-                vol.Optional(CONF_LIGHTS, default=options.get(CONF_LIGHTS)): str,
-                vol.Optional(CONF_XFAN, default=options.get(CONF_XFAN)): str,
-                vol.Optional(CONF_HEALTH, default=options.get(CONF_HEALTH)): str,
-                vol.Optional(CONF_POWERSAVE, default=options.get(CONF_POWERSAVE)): str,
-                vol.Optional(CONF_SLEEP, default=options.get(CONF_SLEEP)): str,
-                vol.Optional(CONF_EIGHTDEGHEAT, default=options.get(CONF_EIGHTDEGHEAT)): str,
-                vol.Optional(CONF_AIR, default=options.get(CONF_AIR)): str,
-                vol.Optional(CONF_TARGET_TEMP, default=options.get(CONF_TARGET_TEMP)): str,
-                vol.Optional(CONF_AUTO_XFAN, default=options.get(CONF_AUTO_XFAN)): str,
-                vol.Optional(CONF_AUTO_LIGHT, default=options.get(CONF_AUTO_LIGHT)): str,
-                vol.Optional(CONF_HORIZONTAL_SWING, default=options.get(CONF_HORIZONTAL_SWING, False)): bool,
-                vol.Optional(CONF_ANTI_DIRECT_BLOW, default=options.get(CONF_ANTI_DIRECT_BLOW)): str,
-                vol.Optional(CONF_DISABLE_AVAILABLE_CHECK, default=options.get(CONF_DISABLE_AVAILABLE_CHECK, False)): bool,
-                vol.Optional(CONF_MAX_ONLINE_ATTEMPTS, default=options.get(CONF_MAX_ONLINE_ATTEMPTS, 3)): int,
-                vol.Optional(CONF_LIGHT_SENSOR, default=options.get(CONF_LIGHT_SENSOR)): str,
-                vol.Optional(CONF_TEMP_SENSOR_OFFSET, default=options.get(CONF_TEMP_SENSOR_OFFSET)): bool,
-                vol.Optional(CONF_LANGUAGE, default=options.get(CONF_LANGUAGE)): str,
+                vol.Optional(
+                    CONF_TARGET_TEMP_STEP,
+                    default=options.get(CONF_TARGET_TEMP_STEP, DEFAULT_TARGET_TEMP_STEP),
+                ): vol.Coerce(float),
+                vol.Optional(
+                    CONF_TEMP_SENSOR, default=options.get(CONF_TEMP_SENSOR)
+                ): vol.Any(str, None),
+                vol.Optional(CONF_LIGHTS, default=options.get(CONF_LIGHTS)): vol.Any(
+                    str, None
+                ),
+                vol.Optional(CONF_XFAN, default=options.get(CONF_XFAN)): vol.Any(
+                    str, None
+                ),
+                vol.Optional(CONF_HEALTH, default=options.get(CONF_HEALTH)): vol.Any(
+                    str, None
+                ),
+                vol.Optional(
+                    CONF_POWERSAVE, default=options.get(CONF_POWERSAVE)
+                ): vol.Any(str, None),
+                vol.Optional(CONF_SLEEP, default=options.get(CONF_SLEEP)): vol.Any(
+                    str, None
+                ),
+                vol.Optional(
+                    CONF_EIGHTDEGHEAT, default=options.get(CONF_EIGHTDEGHEAT)
+                ): vol.Any(str, None),
+                vol.Optional(CONF_AIR, default=options.get(CONF_AIR)): vol.Any(
+                    str, None
+                ),
+                vol.Optional(
+                    CONF_TARGET_TEMP, default=options.get(CONF_TARGET_TEMP)
+                ): vol.Any(str, None),
+                vol.Optional(
+                    CONF_AUTO_XFAN, default=options.get(CONF_AUTO_XFAN)
+                ): vol.Any(str, None),
+                vol.Optional(
+                    CONF_AUTO_LIGHT, default=options.get(CONF_AUTO_LIGHT)
+                ): vol.Any(str, None),
+                vol.Optional(
+                    CONF_HORIZONTAL_SWING,
+                    default=options.get(CONF_HORIZONTAL_SWING, False),
+                ): bool,
+                vol.Optional(
+                    CONF_ANTI_DIRECT_BLOW, default=options.get(CONF_ANTI_DIRECT_BLOW)
+                ): vol.Any(str, None),
+                vol.Optional(
+                    CONF_DISABLE_AVAILABLE_CHECK,
+                    default=options.get(CONF_DISABLE_AVAILABLE_CHECK, False),
+                ): bool,
+                vol.Optional(
+                    CONF_MAX_ONLINE_ATTEMPTS,
+                    default=options.get(CONF_MAX_ONLINE_ATTEMPTS, 3),
+                ): int,
+                vol.Optional(
+                    CONF_LIGHT_SENSOR, default=options.get(CONF_LIGHT_SENSOR)
+                ): vol.Any(str, None),
+                vol.Optional(
+                    CONF_TEMP_SENSOR_OFFSET,
+                    default=options.get(CONF_TEMP_SENSOR_OFFSET),
+                ): vol.Any(bool, None),
+                vol.Optional(CONF_LANGUAGE, default=options.get(CONF_LANGUAGE)): vol.Any(
+                    str, None
+                ),
             }
         )
         return self.async_show_form(step_id="init", data_schema=schema)

--- a/custom_components/gree/config_flow.py
+++ b/custom_components/gree/config_flow.py
@@ -6,6 +6,7 @@ import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.core import callback
+from homeassistant.helpers import selector
 from homeassistant.const import (
     CONF_HOST,
     CONF_MAC,
@@ -57,7 +58,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Handle the initial step."""
         if user_input is not None:
             self._data.update(user_input)
-            return self.async_create_entry(title=user_input.get(CONF_NAME) or "Gree Climate", data=self._data)
+            return self.async_create_entry(
+                title=user_input.get(CONF_NAME) or "Gree Climate", data=self._data
+            )
 
         data_schema = vol.Schema(
             {
@@ -79,7 +82,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
-    def async_get_options_flow(config_entry: config_entries.ConfigEntry) -> config_entries.OptionsFlow:
+    def async_get_options_flow(
+        config_entry: config_entries.ConfigEntry,
+    ) -> config_entries.OptionsFlow:
         return OptionsFlowHandler(config_entry)
 
 
@@ -98,48 +103,90 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             {
                 vol.Optional(
                     CONF_TARGET_TEMP_STEP,
-                    default=options.get(CONF_TARGET_TEMP_STEP, DEFAULT_TARGET_TEMP_STEP),
+                    default=options.get(
+                        CONF_TARGET_TEMP_STEP, DEFAULT_TARGET_TEMP_STEP
+                    ),
                 ): vol.Coerce(float),
                 vol.Optional(
                     CONF_TEMP_SENSOR, default=options.get(CONF_TEMP_SENSOR)
                 ): vol.Any(None, str),
                 vol.Optional(CONF_LIGHTS, default=options.get(CONF_LIGHTS)): vol.Any(
-                    None, str
+                    None,
+                    selector.EntitySelector(
+                        selector.EntitySelectorConfig(domain="input_boolean")
+                    ),
                 ),
                 vol.Optional(CONF_XFAN, default=options.get(CONF_XFAN)): vol.Any(
-                    None, str
+                    None,
+                    selector.EntitySelector(
+                        selector.EntitySelectorConfig(domain="input_boolean")
+                    ),
                 ),
                 vol.Optional(CONF_HEALTH, default=options.get(CONF_HEALTH)): vol.Any(
-                    None, str
+                    None,
+                    selector.EntitySelector(
+                        selector.EntitySelectorConfig(domain="input_boolean")
+                    ),
                 ),
                 vol.Optional(
                     CONF_POWERSAVE, default=options.get(CONF_POWERSAVE)
-                ): vol.Any(None, str),
+                ): vol.Any(
+                    None,
+                    selector.EntitySelector(
+                        selector.EntitySelectorConfig(domain="input_boolean")
+                    ),
+                ),
                 vol.Optional(CONF_SLEEP, default=options.get(CONF_SLEEP)): vol.Any(
-                    None, str
+                    None,
+                    selector.EntitySelector(
+                        selector.EntitySelectorConfig(domain="input_boolean")
+                    ),
                 ),
                 vol.Optional(
                     CONF_EIGHTDEGHEAT, default=options.get(CONF_EIGHTDEGHEAT)
-                ): vol.Any(None, str),
+                ): vol.Any(
+                    None,
+                    selector.EntitySelector(
+                        selector.EntitySelectorConfig(domain="input_boolean")
+                    ),
+                ),
                 vol.Optional(CONF_AIR, default=options.get(CONF_AIR)): vol.Any(
-                    None, str
+                    None,
+                    selector.EntitySelector(
+                        selector.EntitySelectorConfig(domain="input_boolean")
+                    ),
                 ),
                 vol.Optional(
                     CONF_TARGET_TEMP, default=options.get(CONF_TARGET_TEMP)
                 ): vol.Any(None, str),
                 vol.Optional(
                     CONF_AUTO_XFAN, default=options.get(CONF_AUTO_XFAN)
-                ): vol.Any(None, str),
+                ): vol.Any(
+                    None,
+                    selector.EntitySelector(
+                        selector.EntitySelectorConfig(domain="input_boolean")
+                    ),
+                ),
                 vol.Optional(
                     CONF_AUTO_LIGHT, default=options.get(CONF_AUTO_LIGHT)
-                ): vol.Any(None, str),
+                ): vol.Any(
+                    None,
+                    selector.EntitySelector(
+                        selector.EntitySelectorConfig(domain="input_boolean")
+                    ),
+                ),
                 vol.Optional(
                     CONF_HORIZONTAL_SWING,
                     default=options.get(CONF_HORIZONTAL_SWING, False),
                 ): bool,
                 vol.Optional(
                     CONF_ANTI_DIRECT_BLOW, default=options.get(CONF_ANTI_DIRECT_BLOW)
-                ): vol.Any(None, str),
+                ): vol.Any(
+                    None,
+                    selector.EntitySelector(
+                        selector.EntitySelectorConfig(domain="input_boolean")
+                    ),
+                ),
                 vol.Optional(
                     CONF_DISABLE_AVAILABLE_CHECK,
                     default=options.get(CONF_DISABLE_AVAILABLE_CHECK, False),
@@ -150,14 +197,19 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 ): int,
                 vol.Optional(
                     CONF_LIGHT_SENSOR, default=options.get(CONF_LIGHT_SENSOR)
-                ): vol.Any(None, str),
+                ): vol.Any(
+                    None,
+                    selector.EntitySelector(
+                        selector.EntitySelectorConfig(domain="input_boolean")
+                    ),
+                ),
                 vol.Optional(
                     CONF_TEMP_SENSOR_OFFSET,
                     default=options.get(CONF_TEMP_SENSOR_OFFSET),
                 ): vol.Any(None, bool),
-                vol.Optional(CONF_LANGUAGE, default=options.get(CONF_LANGUAGE)): vol.Any(
-                    None, str
-                ),
+                vol.Optional(
+                    CONF_LANGUAGE, default=options.get(CONF_LANGUAGE)
+                ): vol.Any(None, str),
             }
         )
         return self.async_show_form(step_id="init", data_schema=schema)

--- a/custom_components/gree/config_flow.py
+++ b/custom_components/gree/config_flow.py
@@ -109,7 +109,12 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 ): vol.Coerce(float),
                 vol.Optional(
                     CONF_TEMP_SENSOR, default=options.get(CONF_TEMP_SENSOR)
-                ): vol.Any(None, str),
+                ): vol.Any(
+                    None,
+                    selector.EntitySelector(
+                        selector.EntitySelectorConfig(domain="sensor")
+                    ),
+                ),
                 vol.Optional(CONF_LIGHTS, default=options.get(CONF_LIGHTS)): vol.Any(
                     None,
                     selector.EntitySelector(
@@ -158,7 +163,12 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 ),
                 vol.Optional(
                     CONF_TARGET_TEMP, default=options.get(CONF_TARGET_TEMP)
-                ): vol.Any(None, str),
+                ): vol.Any(
+                    None,
+                    selector.EntitySelector(
+                        selector.EntitySelectorConfig(domain="input_number")
+                    ),
+                ),
                 vol.Optional(
                     CONF_AUTO_XFAN, default=options.get(CONF_AUTO_XFAN)
                 ): vol.Any(

--- a/custom_components/gree/config_flow.py
+++ b/custom_components/gree/config_flow.py
@@ -102,44 +102,44 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 ): vol.Coerce(float),
                 vol.Optional(
                     CONF_TEMP_SENSOR, default=options.get(CONF_TEMP_SENSOR)
-                ): vol.Any(str, None),
+                ): vol.Any(None, str),
                 vol.Optional(CONF_LIGHTS, default=options.get(CONF_LIGHTS)): vol.Any(
-                    str, None
+                    None, str
                 ),
                 vol.Optional(CONF_XFAN, default=options.get(CONF_XFAN)): vol.Any(
-                    str, None
+                    None, str
                 ),
                 vol.Optional(CONF_HEALTH, default=options.get(CONF_HEALTH)): vol.Any(
-                    str, None
+                    None, str
                 ),
                 vol.Optional(
                     CONF_POWERSAVE, default=options.get(CONF_POWERSAVE)
-                ): vol.Any(str, None),
+                ): vol.Any(None, str),
                 vol.Optional(CONF_SLEEP, default=options.get(CONF_SLEEP)): vol.Any(
-                    str, None
+                    None, str
                 ),
                 vol.Optional(
                     CONF_EIGHTDEGHEAT, default=options.get(CONF_EIGHTDEGHEAT)
-                ): vol.Any(str, None),
+                ): vol.Any(None, str),
                 vol.Optional(CONF_AIR, default=options.get(CONF_AIR)): vol.Any(
-                    str, None
+                    None, str
                 ),
                 vol.Optional(
                     CONF_TARGET_TEMP, default=options.get(CONF_TARGET_TEMP)
-                ): vol.Any(str, None),
+                ): vol.Any(None, str),
                 vol.Optional(
                     CONF_AUTO_XFAN, default=options.get(CONF_AUTO_XFAN)
-                ): vol.Any(str, None),
+                ): vol.Any(None, str),
                 vol.Optional(
                     CONF_AUTO_LIGHT, default=options.get(CONF_AUTO_LIGHT)
-                ): vol.Any(str, None),
+                ): vol.Any(None, str),
                 vol.Optional(
                     CONF_HORIZONTAL_SWING,
                     default=options.get(CONF_HORIZONTAL_SWING, False),
                 ): bool,
                 vol.Optional(
                     CONF_ANTI_DIRECT_BLOW, default=options.get(CONF_ANTI_DIRECT_BLOW)
-                ): vol.Any(str, None),
+                ): vol.Any(None, str),
                 vol.Optional(
                     CONF_DISABLE_AVAILABLE_CHECK,
                     default=options.get(CONF_DISABLE_AVAILABLE_CHECK, False),
@@ -150,13 +150,13 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 ): int,
                 vol.Optional(
                     CONF_LIGHT_SENSOR, default=options.get(CONF_LIGHT_SENSOR)
-                ): vol.Any(str, None),
+                ): vol.Any(None, str),
                 vol.Optional(
                     CONF_TEMP_SENSOR_OFFSET,
                     default=options.get(CONF_TEMP_SENSOR_OFFSET),
-                ): vol.Any(bool, None),
+                ): vol.Any(None, bool),
                 vol.Optional(CONF_LANGUAGE, default=options.get(CONF_LANGUAGE)): vol.Any(
-                    str, None
+                    None, str
                 ),
             }
         )


### PR DESCRIPTION
## Summary
- allow `None` values in config option fields so editing an integration without optional entries doesn't fail

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840c13e24ec8321b5fd3e8ec48041c4