### PR TITLE
Add beeper functionality

### DIFF
--- a/custom_components/gree/climate.py
+++ b/custom_components/gree/climate.py
@@ -70,7 +70,7 @@ CONF_ENCRYPTION_VERSION = 'encryption_version'
 CONF_DISABLE_AVAILABLE_CHECK  = 'disable_available_check'
 CONF_MAX_ONLINE_ATTEMPTS = 'max_online_attempts'
 CONF_LIGHT_SENSOR = 'light_sensor'
-CONF_BEEPER_ENTITY_ID = 'beeper_entity_id'
+CONF_BEEPER = 'beeper'
 CONF_TEMP_SENSOR_OFFSET = 'temp_sensor_offset'
 CONF_LANGUAGE = 'language'
 
@@ -126,7 +126,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_DISABLE_AVAILABLE_CHECK, default=False): cv.boolean,
     vol.Optional(CONF_MAX_ONLINE_ATTEMPTS, default=3): cv.positive_int,
     vol.Optional(CONF_LIGHT_SENSOR): cv.entity_id,
-    vol.Optional(CONF_BEEPER_ENTITY_ID): cv.entity_id,
+    vol.Optional(CONF_BEEPER): cv.entity_id,
     vol.Optional(CONF_TEMP_SENSOR_OFFSET): cv.boolean,
     vol.Optional(CONF_LANGUAGE): cv.string,
 })
@@ -172,7 +172,7 @@ async def async_setup_platform(hass, config, async_add_devices, discovery_info=N
     encryption_version = config.get(CONF_ENCRYPTION_VERSION)
     disable_available_check = config.get(CONF_DISABLE_AVAILABLE_CHECK)
     max_online_attempts = config.get(CONF_MAX_ONLINE_ATTEMPTS)
-    beeper_entity_id = config.get(CONF_BEEPER_ENTITY_ID)
+    beeper_entity_id = config.get(CONF_BEEPER)
     temp_sensor_offset = config.get(CONF_TEMP_SENSOR_OFFSET)
 
     _LOGGER.info('Adding Gree climate device to hass')

--- a/custom_components/gree/config_flow.py
+++ b/custom_components/gree/config_flow.py
@@ -43,6 +43,7 @@ from .climate import (
     CONF_LIGHT_SENSOR,
     CONF_TEMP_SENSOR_OFFSET,
     CONF_LANGUAGE,
+    CONF_BEEPER
 )
 
 
@@ -207,6 +208,14 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 ): int,
                 vol.Optional(
                     CONF_LIGHT_SENSOR, default=options.get(CONF_LIGHT_SENSOR)
+                ): vol.Any(
+                    None,
+                    selector.EntitySelector(
+                        selector.EntitySelectorConfig(domain="input_boolean")
+                    ),
+                ),
+                vol.Optional(
+                    CONF_BEEPER, default=options.get(CONF_BEEPER)
                 ): vol.Any(
                     None,
                     selector.EntitySelector(

--- a/custom_components/gree/translations/en.json
+++ b/custom_components/gree/translations/en.json
@@ -42,7 +42,8 @@
       "encryption_version": "Encryption Version",
       "disable_available_check": "Disable Available Check",
       "max_online_attempts": "Max Online Attempts",
-      "temp_sensor_offset": "Temperature Sensor Offset"
+      "temp_sensor_offset": "Temperature Sensor Offset",
+      "beeper": "Beeper Entity"
     }
   },
   "options": {
@@ -68,6 +69,7 @@
           "max_online_attempts": "Max Online Attempts",
           "light_sensor": "Light Sensor Entity",
           "temp_sensor_offset": "Temperature Sensor Offset",
+          "beeper": "Beeper Entity",
           "language": "Language"
         }
       }


### PR DESCRIPTION
The modification allows sending silent commands without beeping both for manual control and in automations.

An example of how to assign an entity to toggle a beeper:
In the climate.yaml file:
 beeper_entity_id: input_boolean.living_room_ac_beep

When the boolean is true it beeps, when it's false it doesn't.

Occasionally beeps even when false and requires toggling on, off for some reason.

Also a small correction for line 857.
