### PR TITLE
Add autodiscovery to Gree config flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ This component is added to HACS default repository list.
 ## UI Configuration
 The integration can be added from the Home Assistant UI.
 1. Navigate to **Settings** > **Devices & Services** and click **Add Integration**.
-2. Search for **Gree Climate** and fill in the host, port and MAC address.
+2. Search for **Gree Climate**. The setup will scan the network for compatible units and lets you select one from the list or enter the details manually.
 3. After setup you can open the integration options to configure additional parameters.
 
 ## Custom Component Installation

--- a/custom_components/gree/manifest.json
+++ b/custom_components/gree/manifest.json
@@ -9,7 +9,8 @@
   ],
   "requirements": [
     "pycryptodome",
-    "aiofiles"
+    "aiofiles",
+    "greeclimate>=2.1.0"
   ],
   "config_flow": true
 }

--- a/info.md
+++ b/info.md
@@ -3,6 +3,7 @@
 ## UI Configuration
 You can add the integration from the Home Assistant UI.
 Navigate to **Settings** > **Devices & Services** and search for **Gree Climate**.
+The setup will scan your network for compatible units and let you select one from the list or add it manually.
 
 ## Component configuration
 To configure this component manually, add the following configuration to your configuration.yaml (replacing the placeholders).


### PR DESCRIPTION
## Summary
- support device autodiscovery when setting up integration
- require `greeclimate` library
- document autodiscovery in README and info

## Testing
- `python -m py_compile custom_components/gree/config_flow.py`
- `pytest -q`
- `python -m compileall -q custom_components/gree`

------
https://chatgpt.com/codex/tasks/task_e_6841ae7f44748321bfbbdeb617aaf956