### PR TITLE
Add Argo ECOLIGHT 9000 with Wifi Module

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Tested on the following hardware:
 - AC Pioneer Fortis Series with WI-FI module CS532AE
 - AC Gree GWH12ACC-K6DNA1D
 - AC Gree 3VIR24HP230V1AH
+- Argo ECOLIGHT 9000 UI WF - Split Air Conditioner Unit (Pair through EWPE Smart app, default settings in gree are fine)
 - Bulex vivair multisplit units; 20-080MC4NO outdoor unit, 20-025 NWI (2,5 kW) indoor unit, 20-035 NWI (3,5 kW) indoor unit
 - CASCADE BORA-CWH09AAB
 - Cooper & Hunter (CH-S12FTXE(WI-FI)-NG)


### PR DESCRIPTION
Split air conditioner unit - no additional steps were required beyond completing the Wifi setup as directed by the EWPE Smart app. I had to get the IP Address & Mac Addresses from my router as they are not shown in the app. I also set a static IP address for all of my units while I was there.

The default settings (incl. encryption) in the gree integration GUI worked fine. I have not looked into the optional functions, but all the major functions + temp were automatically exposed and work fine.

Note that the units take about 2 minutes to reset themselves after you press the MODE + WIFI combination and hear the beep (app does a bad job of explaining this). When it's reset the temporary direct Wifi network will appear, named for the last 6 digits of its mac address.