### PR TITLE
Use swing_full in horizontal mode as well instead of full_swing for coherence

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ The integration can be added from the Home Assistant UI.
    | `hvac_modes` | Standard Home Assistant HVAC Modes to enable | `list[string]` (e.g. `["auto", "cool", "dry", "fan_only", "off"]`) | `false` | `["auto", "cool", "dry", "fan_only", "heat", "heat_cool", "off"]` |
    | `fan_modes` | Fan modes | `list[string]` (e.g. `["auto", "low", "medium", "high"]`) | `false` | `["auto", "low", "medium_low", "medium", "medium_high", "high", "turbo", "quiet"]` |
    | `swing_modes` | Fan vertical swing modes | `list[string]` (e.g. `["default", "swing_full"]`) <br> **NOTE: Pass empty list (`[]`) to disable vertical swing** | `false` | `["default", "swing_full", "fixed_upmost", "fixed_middle_up", "fixed_middle", "fixed_middle_low", "fixed_lowest", "swing_downmost", "swing_middle_low", "swing_middle", "swing_middle_up", "swing_upmost"]` |
-   | `swing_horizontal_modes` | Fan horizontal swing modes | `list[string]` (e.g. `["default", "full_swing"]`) <br> **NOTE: Pass empty list (`[]`) to disable horizontal swing** | `false` | `["default", "full_swing", "fixed_leftmost", "fixed_middle_left", "fixed_middle", "fixed_middle_right", "fixed_rightmost"]` |
+   | `swing_horizontal_modes` | Fan horizontal swing modes | `list[string]` (e.g. `["default", "swing_full"]`) <br> **NOTE: Pass empty list (`[]`) to disable horizontal swing** | `false` | `["default", "swing_full", "fixed_leftmost", "fixed_middle_left", "fixed_middle", "fixed_middle_right", "fixed_rightmost"]` |
    | `target_temp_step` | Temperature adjustment step | `integer` (e.g., `1`) | `false` | `1` |
    | `uid` | Device identifier | `string` (e.g., `AC_UNIT_123`) | `false` | |
    | `temp_sensor` | External temp sensor entity ID | `entity_id` (e.g., `sensor.bedroom_temperature`) | `false` | |

--- a/climate.yaml
+++ b/climate.yaml
@@ -9,7 +9,7 @@
   hvac_modes: ['auto', 'dry', 'cool', 'fan_only', 'heat', 'off']
   fan_modes: ['auto' ,'low', 'medium_low', 'medium', 'medium_high', 'high', 'quiet', 'turbo']
   swing_modes: ['default', 'swing_full', 'fixed_upmost', 'fixed_middle_up', 'fixed_middle', 'fixed_middle_low', 'fixed_lowest', 'swing_downmost', 'swing_middle_low', 'swing_middle', 'swing_middle_up', 'swing_upmost']
-  swing_horizontal_modes: ['default', 'full_swing', 'fixed_leftmost', 'fixed_middle_left', 'fixed_middle', 'fixed_middle_right', 'fixed_rightmost']
+  swing_horizontal_modes: ['default', 'swing_full', 'fixed_leftmost', 'fixed_middle_left', 'fixed_middle', 'fixed_middle_right', 'fixed_rightmost']
   target_temp_step: 1
   temp_sensor: <temperature sensor in first AC room>
   lights: <input_boolean used to switch lights on/off of your first AC>

--- a/custom_components/gree/climate.py
+++ b/custom_components/gree/climate.py
@@ -118,7 +118,7 @@ DEFAULT_HVAC_MODES = ["auto", "cool", "dry", "fan_only", "heat", "heat_cool", "o
 
 DEFAULT_FAN_MODES = ["auto", "low", "medium_low", "medium", "medium_high", "high", "turbo", "quiet"]
 DEFAULT_SWING_MODES = ["default", "swing_full", "fixed_upmost", "fixed_middle_up", "fixed_middle", "fixed_middle_low", "fixed_lowest", "swing_downmost", "swing_middle_low", "swing_middle", "swing_middle_up", "swing_upmost"]
-DEFAULT_SWING_HORIZONTAL_MODES = ["default", "full_swing", "fixed_leftmost", "fixed_middle_left", "fixed_middle", "fixed_middle_right", "fixed_rightmost"]
+DEFAULT_SWING_HORIZONTAL_MODES = ["default", "swing_full", "fixed_leftmost", "fixed_middle_left", "fixed_middle", "fixed_middle_right", "fixed_rightmost"]
 
 GCM_IV = b'\x54\x40\x78\x44\x49\x67\x5a\x51\x6c\x5e\x63\x13'
 GCM_ADD = b'qualcomm-test'

--- a/custom_components/gree/icons.json
+++ b/custom_components/gree/icons.json
@@ -20,7 +20,7 @@
             "default": "mdi:arrow-oscillating",
             "state": {
               "default": "mdi:arrow-oscillating-off",
-              "full_swing": "mdi:arrow-oscillating"
+              "swing_full": "mdi:arrow-oscillating"
             }
           },
           "swing_mode": {

--- a/custom_components/gree/translations/de.json
+++ b/custom_components/gree/translations/de.json
@@ -123,7 +123,7 @@
     "swing_horizontal_modes": {
       "options": {
         "default": "Standard",
-        "full_swing": "Vollständiges Schwingen",
+        "swing_full": "Vollständiges Schwingen",
         "fixed_leftmost": "Fest in der linken Position",
         "fixed_middle_left": "Fest in der mittleren-linken Position",
         "fixed_middle": "Fest in der mittleren Position",
@@ -167,7 +167,7 @@
           "swing_horizontal_mode": {
             "state": {
               "default": "Standard",
-              "full_swing": "Vollständiges Schwingen",
+              "swing_full": "Vollständiges Schwingen",
               "fixed_leftmost": "Fest in der linken Position",
               "fixed_middle_left": "Fest in der mittleren-linken Position",
               "fixed_middle": "Fest in der mittleren Position",

--- a/custom_components/gree/translations/en.json
+++ b/custom_components/gree/translations/en.json
@@ -123,7 +123,7 @@
     "swing_horizontal_modes": {
       "options": {
         "default": "Default",
-        "full_swing": "Full swing",
+        "swing_full": "Full swing",
         "fixed_leftmost": "Fixed in the leftmost position",
         "fixed_middle_left": "Fixed in the middle-left position",
         "fixed_middle": "Fixed in the middle position",
@@ -167,7 +167,7 @@
           "swing_horizontal_mode": {
             "state": {
               "default": "Default",
-              "full_swing": "Full swing",
+              "swing_full": "Swing in full range",
               "fixed_leftmost": "Fixed in the leftmost position",
               "fixed_middle_left": "Fixed in the middle-left position",
               "fixed_middle": "Fixed in the middle position",

--- a/custom_components/gree/translations/he.json
+++ b/custom_components/gree/translations/he.json
@@ -123,7 +123,7 @@
     "swing_horizontal_modes": {
       "options": {
         "default": "ברירת מחדל",
-        "full_swing": "נדנוד מלא",
+        "swing_full": "נדנוד מלא",
         "fixed_leftmost": "קבוע במיקום השמאלי ביותר",
         "fixed_middle_left": "קבוע במיקום אמצעי-שמאלי",
         "fixed_middle": "קבוע במיקום האמצעי",
@@ -167,7 +167,7 @@
           "swing_horizontal_mode": {
             "state": {
               "default": "ברירת מחדל",
-              "full_swing": "נדנוד מלא",
+              "swing_full": "נדנוד מלא",
               "fixed_leftmost": "קבוע במיקום השמאלי ביותר",
               "fixed_middle_left": "קבוע במיקום אמצעי-שמאלי",
               "fixed_middle": "קבוע במיקום האמצעי",

--- a/custom_components/gree/translations/hu.json
+++ b/custom_components/gree/translations/hu.json
@@ -123,7 +123,7 @@
     "swing_horizontal_modes": {
       "options": {
         "default": "Alapértelmezett",
-        "full_swing": "Teljes lengés",
+        "swing_full": "Teljes lengés",
         "fixed_leftmost": "Rögzített bal szélső pozíció",
         "fixed_middle_left": "Rögzített közép-bal pozíció",
         "fixed_middle": "Rögzített középső pozíció",
@@ -167,7 +167,7 @@
           "swing_horizontal_mode": {
             "state": {
               "default": "Alapértelmezett",
-              "full_swing": "Teljes lengés",
+              "swing_full": "Teljes lengés",
               "fixed_leftmost": "Rögzített bal szélső pozíció",
               "fixed_middle_left": "Rögzített közép-bal pozíció",
               "fixed_middle": "Rögzített középső pozíció",

--- a/custom_components/gree/translations/it.json
+++ b/custom_components/gree/translations/it.json
@@ -123,7 +123,7 @@
     "swing_horizontal_modes": {
       "options": {
         "default": "Predefinito",
-        "full_swing": "Oscillazione completa",
+        "swing_full": "Oscillazione completa",
         "fixed_leftmost": "Fisso in posizione più a sinistra",
         "fixed_middle_left": "Fisso in posizione medio-sinistra",
         "fixed_middle": "Fisso in posizione centrale",
@@ -167,7 +167,7 @@
           "swing_horizontal_mode": {
             "state": {
               "default": "Predefinito",
-              "full_swing": "Oscillazione completa",
+              "swing_full": "Oscillazione completa",
               "fixed_leftmost": "Fisso in posizione più a sinistra",
               "fixed_middle_left": "Fisso in posizione medio-sinistra",
               "fixed_middle": "Fisso in posizione centrale",

--- a/custom_components/gree/translations/pl.json
+++ b/custom_components/gree/translations/pl.json
@@ -123,7 +123,7 @@
     "swing_horizontal_modes": {
       "options": {
         "default": "Domyślny",
-        "full_swing": "Ruch w pełnym zakresie",
+        "swing_full": "Ruch w pełnym zakresie",
         "fixed_leftmost": "Stały w skrajnie lewej pozycji",
         "fixed_middle_left": "Stały w pozycji środkowo-lewej",
         "fixed_middle": "Stały w pozycji środkowej",
@@ -167,7 +167,7 @@
           "swing_horizontal_mode": {
             "state": {
               "default": "Domyślny",
-              "full_swing": "Ruch w pełnym zakresie",
+              "swing_full": "Ruch w pełnym zakresie",
               "fixed_leftmost": "Stały w skrajnie lewej pozycji",
               "fixed_middle_left": "Stały w pozycji środkowo-lewej",
               "fixed_middle": "Stały w pozycji środkowej",

--- a/custom_components/gree/translations/ro.json
+++ b/custom_components/gree/translations/ro.json
@@ -123,7 +123,7 @@
     "swing_horizontal_modes": {
       "options": {
         "default": "Implicit",
-        "full_swing": "Balansare completă",
+        "swing_full": "Balansare completă",
         "fixed_leftmost": "Fixat în poziția cea mai la stânga",
         "fixed_middle_left": "Fixat în poziția mijloc-stânga",
         "fixed_middle": "Fixat în poziția de mijloc",
@@ -167,7 +167,7 @@
           "swing_horizontal_mode": {
             "state": {
               "default": "Implicit",
-              "full_swing": "Balansare completă",
+              "swing_full": "Balansare completă",
               "fixed_leftmost": "Fixat în poziția cea mai la stânga",
               "fixed_middle_left": "Fixat în poziția mijloc-stânga",
               "fixed_middle": "Fixat în poziția de mijloc",

--- a/custom_components/gree/translations/ru.json
+++ b/custom_components/gree/translations/ru.json
@@ -123,7 +123,7 @@
     "swing_horizontal_modes": {
       "options": {
         "default": "По умолчанию",
-        "full_swing": "Полное качание",
+        "swing_full": "Полное качание",
         "fixed_leftmost": "Фиксировано в крайнем левом положении",
         "fixed_middle_left": "Фиксировано в среднем-левом положении",
         "fixed_middle": "Фиксировано в среднем положении",
@@ -167,7 +167,7 @@
           "swing_horizontal_mode": {
             "state": {
               "default": "По умолчанию",
-              "full_swing": "Полное качание",
+              "swing_full": "Полное качание",
               "fixed_leftmost": "Фиксировано в крайнем левом положении",
               "fixed_middle_left": "Фиксировано в среднем-левом положении",
               "fixed_middle": "Фиксировано в среднем положении",


### PR DESCRIPTION
### Changes
- Replaced all instances of `full_swing` with `swing_full` in horizontal swing modes to make it coherent with the swing modes format
- Updated the English translation for horizontal full swing from `Full swing` to `Swing in full range` for coherence

**Note: This might break your climate cards that use `full_swing` or its translation. Please update them with `swing_full` or its localized equivalent.**