### PR TITLE
Fix for incorrect mapping for HVAC, fan, and swing modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Tested on the following hardware:
 - Innova HVAC
 - Inventor Life Pro WiFi
 - Kinghome "Pular" - KW12HQ25SDI (Requires encryption_version=2)
-- Kolin KAG-100WCINV
-- Kolin KAG-145WCINV
+- Kolin KAG-100WCINV (Requires encryption_version=2)
+- Kolin KAG-145WCINV (Requires encryption_version=2)
 - Saunier Duval VivAir Lite SDHB1-025SNWI (Requires encryption_version=2)
 - Saunier Duval VivAir Lite SDHB1-035SNWI (Requires encryption_version=2)
 - Sinclair ASH-12BIV

--- a/custom_components/gree/climate.py
+++ b/custom_components/gree/climate.py
@@ -47,32 +47,6 @@ _LOGGER = logging.getLogger(__name__)
 
 SUPPORT_FLAGS = ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.FAN_MODE | ClimateEntityFeature.TURN_ON | ClimateEntityFeature.TURN_OFF
 
-# Keys that can be updated via the options flow
-OPTION_KEYS = {
-    CONF_HVAC_MODES,
-    CONF_TARGET_TEMP_STEP,
-    CONF_TEMP_SENSOR,
-    CONF_LIGHTS,
-    CONF_XFAN,
-    CONF_HEALTH,
-    CONF_POWERSAVE,
-    CONF_SLEEP,
-    CONF_EIGHTDEGHEAT,
-    CONF_AIR,
-    CONF_TARGET_TEMP,
-    CONF_AUTO_XFAN,
-    CONF_AUTO_LIGHT,
-    CONF_FAN_MODES,
-    CONF_SWING_MODES,
-    CONF_SWING_HORIZONTAL_MODES,
-    CONF_ANTI_DIRECT_BLOW,
-    CONF_DISABLE_AVAILABLE_CHECK,
-    CONF_MAX_ONLINE_ATTEMPTS,
-    CONF_LIGHT_SENSOR,
-    CONF_BEEPER,
-    CONF_TEMP_SENSOR_OFFSET,
-}
-
 # from the remote control and gree app
 
 # update() interval

--- a/custom_components/gree/climate.py
+++ b/custom_components/gree/climate.py
@@ -108,7 +108,8 @@ async def async_setup_platform(hass, config, async_add_devices, discovery_info=N
     air_entity_id = config.get(CONF_AIR)
     target_temp_entity_id = config.get(CONF_TARGET_TEMP)
 
-    hvac_modes = [getattr(HVACMode, key.upper()) for key in config.get(CONF_HVAC_MODES)]
+    chm = config.get(CONF_HVAC_MODES)
+    hvac_modes = [getattr(HVACMode, mode.upper()) for mode in (chm if chm else DEFAULT_HVAC_MODES)]
 
     fan_modes = config.get(CONF_FAN_MODES)
     swing_modes = config.get(CONF_SWING_MODES)

--- a/custom_components/gree/climate.py
+++ b/custom_components/gree/climate.py
@@ -97,7 +97,8 @@ async def async_setup_platform(hass, config, async_add_devices, discovery_info=N
     mac_addr = config.get(CONF_MAC).encode().replace(b':', b'')
     timeout = config.get(CONF_TIMEOUT)
 
-    target_temp_step = config.get(CONF_TARGET_TEMP_STEP)
+    ctts = config.get(CONF_TARGET_TEMP_STEP)
+    target_temp_step = ctts if ctts is not None else DEFAULT_TARGET_TEMP_STEP
     temp_sensor_entity_id = config.get(CONF_TEMP_SENSOR)
     lights_entity_id = config.get(CONF_LIGHTS)
     xfan_entity_id = config.get(CONF_XFAN)
@@ -109,7 +110,7 @@ async def async_setup_platform(hass, config, async_add_devices, discovery_info=N
     target_temp_entity_id = config.get(CONF_TARGET_TEMP)
 
     chm = config.get(CONF_HVAC_MODES)
-    hvac_modes = [getattr(HVACMode, mode.upper()) for mode in (chm if chm else DEFAULT_HVAC_MODES)]
+    hvac_modes = [getattr(HVACMode, mode.upper()) for mode in (chm if chm is not None else DEFAULT_HVAC_MODES)]
 
     fan_modes = config.get(CONF_FAN_MODES)
     swing_modes = config.get(CONF_SWING_MODES)

--- a/custom_components/gree/climate.py
+++ b/custom_components/gree/climate.py
@@ -112,9 +112,12 @@ async def async_setup_platform(hass, config, async_add_devices, discovery_info=N
     chm = config.get(CONF_HVAC_MODES)
     hvac_modes = [getattr(HVACMode, mode.upper()) for mode in (chm if chm is not None else DEFAULT_HVAC_MODES)]
 
-    fan_modes = config.get(CONF_FAN_MODES)
-    swing_modes = config.get(CONF_SWING_MODES)
-    swing_horizontal_modes = config.get(CONF_SWING_HORIZONTAL_MODES)
+    cfm = config.get(CONF_FAN_MODES)
+    fan_modes = cfm if cfm is not None else DEFAULT_FAN_MODES
+    csm = config.get(CONF_SWING_MODES)
+    swing_modes = csm if csm is not None else DEFAULT_SWING_MODES
+    cshm = config.get(CONF_SWING_HORIZONTAL_MODES)
+    swing_horizontal_modes = cshm if cshm is not None else DEFAULT_SWING_HORIZONTAL_MODES
     encryption_key = config.get(CONF_ENCRYPTION_KEY)
     uid = config.get(CONF_UID)
     auto_xfan_entity_id = config.get(CONF_AUTO_XFAN)

--- a/custom_components/gree/climate.py
+++ b/custom_components/gree/climate.py
@@ -678,17 +678,23 @@ class GreeClimate(ClimateEntity):
         if (self._acOptions['Pow'] == 0):
             self._hvac_mode = HVACMode.OFF
         else:
-            self._hvac_mode = self._hvac_modes[self._acOptions['Mod']]
+            for key, value in MODES_MAPPING.get('Mod').items():
+                if value == (self._acOptions['Mod']):
+                    self._hvac_mode = key
         _LOGGER.debug('HA operation mode set according to HVAC state to: ' + str(self._hvac_mode))
 
     def UpdateHACurrentSwingMode(self):
         # Sync current HVAC Swing mode state to HA
-        self._swing_mode = self._swing_modes[self._acOptions['SwUpDn']]
+        for key, value in MODES_MAPPING.get('SwUpDn').items():
+            if value == (self._acOptions['SwUpDn']):
+                self._swing_mode = key
         _LOGGER.debug('HA swing mode set according to HVAC state to: ' + str(self._swing_mode))
 
     def UpdateHACurrentSwingHorizontalMode(self):
         # Sync current HVAC Horizontal Swing mode state to HA
-        self._swing_horizontal_mode = self._swing_horizontal_modes[self._acOptions['SwingLfRig']]
+        for key, value in MODES_MAPPING.get('SwingLfRig').items():
+            if value == (self._acOptions['SwingLfRig']):
+                self._swing_horizontal_mode = key
         _LOGGER.debug('HA horizontal swing mode set according to HVAC state to: ' + str(self._swing_horizontal_mode))
 
     def UpdateHAFanMode(self):
@@ -700,7 +706,9 @@ class GreeClimate(ClimateEntity):
             quiet_index = self._fan_modes.index('quiet')
             self._fan_mode = self._fan_modes[quiet_index]
         else:
-            self._fan_mode = self._fan_modes[int(self._acOptions['WdSpd'])]
+            for key, value in MODES_MAPPING.get('WdSpd').items():
+                if value == (self._acOptions['WdSpd']):
+                    self._fan_mode = key
         _LOGGER.debug('HA fan mode set according to HVAC state to: ' + str(self._fan_mode))
 
     def UpdateHACurrentTemperature(self):
@@ -1471,9 +1479,9 @@ class GreeClimate(ClimateEntity):
         if not (self._acOptions['Pow'] == 0):
             # do nothing if HVAC is switched off
             try:
-                sw_lf_rig= MODES_MAPPING.get("Mod").get(swing_horizontal_mode)
-                _LOGGER.info('SyncState with SwingLfRig=' + str(sw_lf_rig))
-                self.SyncState({'SwingLfRig': sw_lf_rig})
+                swing_lf_rig= MODES_MAPPING.get("Mod").get(swing_horizontal_mode)
+                _LOGGER.info('SyncState with SwingLfRig=' + str(swing_lf_rig))
+                self.SyncState({'SwingLfRig': swing_lf_rig})
                 self.schedule_update_ha_state()
             except ValueError:
                 _LOGGER.error(f'Unknown preset mode: {swing_horizontal_mode}')

--- a/custom_components/gree/config_flow.py
+++ b/custom_components/gree/config_flow.py
@@ -20,44 +20,7 @@ from homeassistant.data_entry_flow import FlowResult
 
 _LOGGER = logging.getLogger(__name__)
 
-from .const import DOMAIN
-from .climate import (
-    DEFAULT_PORT,
-    DEFAULT_TIMEOUT,
-    DEFAULT_HVAC_MODES,
-    DEFAULT_TARGET_TEMP_STEP,
-    DEFAULT_FAN_MODES,
-    DEFAULT_SWING_MODES,
-    DEFAULT_SWING_HORIZONTAL_MODES,
-    CONF_HVAC_MODES,
-    CONF_TARGET_TEMP_STEP,
-    CONF_TEMP_SENSOR,
-    CONF_LIGHTS,
-    CONF_XFAN,
-    CONF_HEALTH,
-    CONF_POWERSAVE,
-    CONF_SLEEP,
-    CONF_EIGHTDEGHEAT,
-    CONF_AIR,
-    CONF_ENCRYPTION_KEY,
-    CONF_UID,
-    CONF_AUTO_XFAN,
-    CONF_AUTO_LIGHT,
-    CONF_FAN_MODES,
-    CONF_SWING_MODES,
-    CONF_SWING_HORIZONTAL_MODES,
-    CONF_TARGET_TEMP,
-    CONF_ANTI_DIRECT_BLOW,
-    CONF_ENCRYPTION_VERSION,
-    CONF_DISABLE_AVAILABLE_CHECK,
-    CONF_MAX_ONLINE_ATTEMPTS,
-    CONF_LIGHT_SENSOR,
-    CONF_TEMP_SENSOR_OFFSET,
-    CONF_BEEPER,
-    OPTION_KEYS
-)
-
-
+from .const import *
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Gree climate."""
 

--- a/custom_components/gree/const.py
+++ b/custom_components/gree/const.py
@@ -46,6 +46,32 @@ DEFAULT_FAN_MODES = ["auto", "low", "medium_low", "medium", "medium_high", "high
 DEFAULT_SWING_MODES = ["default", "swing_full", "fixed_upmost", "fixed_middle_up", "fixed_middle", "fixed_middle_low", "fixed_lowest", "swing_downmost", "swing_middle_low", "swing_middle", "swing_middle_up", "swing_upmost"]
 DEFAULT_SWING_HORIZONTAL_MODES = ["default", "swing_full", "fixed_leftmost", "fixed_middle_left", "fixed_middle", "fixed_middle_right", "fixed_rightmost"]
 
+# Keys that can be updated via the options flow
+OPTION_KEYS = {
+    CONF_HVAC_MODES,
+    CONF_TARGET_TEMP_STEP,
+    CONF_TEMP_SENSOR,
+    CONF_LIGHTS,
+    CONF_XFAN,
+    CONF_HEALTH,
+    CONF_POWERSAVE,
+    CONF_SLEEP,
+    CONF_EIGHTDEGHEAT,
+    CONF_AIR,
+    CONF_TARGET_TEMP,
+    CONF_AUTO_XFAN,
+    CONF_AUTO_LIGHT,
+    CONF_FAN_MODES,
+    CONF_SWING_MODES,
+    CONF_SWING_HORIZONTAL_MODES,
+    CONF_ANTI_DIRECT_BLOW,
+    CONF_DISABLE_AVAILABLE_CHECK,
+    CONF_MAX_ONLINE_ATTEMPTS,
+    CONF_LIGHT_SENSOR,
+    CONF_BEEPER,
+    CONF_TEMP_SENSOR_OFFSET,
+}
+
 MODES_MAPPING = {
   "Mod" : {
     "auto" : 0,

--- a/custom_components/gree/const.py
+++ b/custom_components/gree/const.py
@@ -102,7 +102,7 @@ MODES_MAPPING = {
     "swing_middle_up" : 10,
     "swing_upmost" : 11
   },
-  "SwLfRig" : {
+  "SwingLfRig" : {
     "default" : 0,
     "swing_full" : 1,
     "fixed_leftmost" : 2,

--- a/custom_components/gree/const.py
+++ b/custom_components/gree/const.py
@@ -1,2 +1,88 @@
 DOMAIN = "gree"
 PLATFORMS = ["climate"]
+
+CONF_HVAC_MODES = "hvac_modes"
+CONF_TARGET_TEMP_STEP = 'target_temp_step'
+CONF_TEMP_SENSOR = 'temp_sensor'
+CONF_LIGHTS = 'lights'
+CONF_XFAN = 'xfan'
+CONF_HEALTH = 'health'
+CONF_POWERSAVE = 'powersave'
+CONF_SLEEP = 'sleep'
+CONF_EIGHTDEGHEAT = 'eightdegheat'
+CONF_AIR = 'air'
+CONF_ENCRYPTION_KEY = 'encryption_key'
+CONF_UID = 'uid'
+CONF_AUTO_XFAN = 'auto_xfan'
+CONF_AUTO_LIGHT = 'auto_light'
+CONF_TARGET_TEMP = 'target_temp'
+CONF_FAN_MODES = 'fan_modes'
+CONF_SWING_MODES = 'swing_modes'
+CONF_SWING_HORIZONTAL_MODES = 'swing_horizontal_modes'
+CONF_ANTI_DIRECT_BLOW = 'anti_direct_blow'
+CONF_ENCRYPTION_VERSION = 'encryption_version'
+CONF_DISABLE_AVAILABLE_CHECK  = 'disable_available_check'
+CONF_MAX_ONLINE_ATTEMPTS = 'max_online_attempts'
+CONF_LIGHT_SENSOR = 'light_sensor'
+CONF_BEEPER = 'beeper'
+CONF_TEMP_SENSOR_OFFSET = 'temp_sensor_offset'
+
+DEFAULT_PORT = 7000
+DEFAULT_TIMEOUT = 10
+DEFAULT_TARGET_TEMP_STEP = 1
+
+MIN_TEMP_C = 16
+MAX_TEMP_C = 30
+
+MIN_TEMP_F = 61
+MAX_TEMP_F = 86
+
+TEMSEN_OFFSET = 40
+
+# HVAC modes - these come from Home Assistant and are standard
+DEFAULT_HVAC_MODES = ["auto", "cool", "dry", "fan_only", "heat", "off"] 
+
+DEFAULT_FAN_MODES = ["auto", "low", "medium_low", "medium", "medium_high", "high", "turbo", "quiet"]
+DEFAULT_SWING_MODES = ["default", "swing_full", "fixed_upmost", "fixed_middle_up", "fixed_middle", "fixed_middle_low", "fixed_lowest", "swing_downmost", "swing_middle_low", "swing_middle", "swing_middle_up", "swing_upmost"]
+DEFAULT_SWING_HORIZONTAL_MODES = ["default", "swing_full", "fixed_leftmost", "fixed_middle_left", "fixed_middle", "fixed_middle_right", "fixed_rightmost"]
+
+MODES_MAPPING = {
+  "Mod" : {
+    "auto" : 0,
+    "cool" : 1,
+    "dry" : 2,
+    "fan_only" : 3,
+    "heat" : 4
+  },
+  "WdSpd" : {
+    "auto" : 0,
+    "low" : 1,
+    "medium_low" : 2,
+    "medium" : 3,
+    "medium_high" : 4,
+    "high" : 5
+  },
+  "SwUpDn" : {
+    "default" : 0,
+    "swing_full" : 1,
+    "fixed_upmost" : 2,
+    "fixed_middle_up" : 3,
+    "fixed_middle" : 4,
+    "fixed_middle_low" : 5,
+    "fixed_lowest" : 6,
+    "swing_downmost" : 7,
+    "swing_middle_low" : 8,
+    "swing_middle" : 9,
+    "swing_middle_up" : 10,
+    "swing_upmost" : 11
+  },
+  "SwLfRig" : {
+    "default" : 0,
+    "swing_full" : 1,
+    "fixed_leftmost" : 2,
+    "fixed_middle_left" : 3,
+    "fixed_middle" : 4,
+    "fixed_middle_right" : 5,
+    "fixed_rightmost" : 6
+  }
+}


### PR DESCRIPTION
Changes:

- Included a reference for mapping values of acOptions to the correct modes so that the values do not depend on the index of a list of modes
- Removed heat_cool in the `DEFAULT_HVAC_MODES` since it's not included in the supported modes from the gree protocol
- Ensured default values for HVAC, fan, and swing modes, as well as target temperature step
- Moved around some constants to the const.py file for clarity
- Updated README.md to include encryption_version detail for Kolin units