### PR TITLE
Fix beeper init when toggle is false and correct reversed log messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ The integration can be added from the Home Assistant UI.
    | `max_online_attempts` | Retry limit before marking unavailable | `integer` (e.g., `5`) | `false` | `3` |
    | `disable_available_check` | Keep AC always available in HA | `boolean` (e.g., `true`) | `false` | `false` |
    | `temp_sensor_offset` | Display offset for temp sensor | `boolean` (e.g., `true`) | `false` | *(auto-detected if not set)* |
-   | `beeper` | Toggle beeping sounds | `input_boolean` (e.g., `input_boolean.first_ac_beeper`) | `false` | |
+   | `beeper` | Toggle beeping sounds (AC beeper) | `input_boolean` (`ON` = AC beeps on commands, `OFF` = silent)<br>(e.g., `input_boolean.first_ac_beeper`) | `false` | |
 
 
 3. In your configuration.yaml add the following:

--- a/custom_components/gree/climate.py
+++ b/custom_components/gree/climate.py
@@ -389,14 +389,14 @@ class GreeClimate(ClimateEntity):
         self._process_temp_sensor = self.TempOffsetResolver()
 
         self._beeper_entity_id = beeper_entity_id
-        self._current_beeper_enabled = True # Default to beeper ON (silent mode OFF)
+        # Default: beeper enabled (not silent)
+        self._current_beeper_enabled = True
 
         if self._beeper_entity_id:
             _LOGGER.info('Setting up beeper control entity: %s', self._beeper_entity_id)
             initial_beeper_state = self.hass.states.get(self._beeper_entity_id)
-            if initial_beeper_state and initial_beeper_state.state == STATE_ON:
-                self._current_beeper_enabled = True
-
+            if initial_beeper_state:
+                self._current_beeper_enabled = initial_beeper_state.state == STATE_ON
             unsub = async_track_state_change_event(
                 hass, self._beeper_entity_id, self._async_beeper_entity_state_changed
             )
@@ -511,7 +511,7 @@ class GreeClimate(ClimateEntity):
 
         opt += ',"Buzzer_ON_OFF"'
         p += ',' + str(buzzer_command_value)
-        _LOGGER.debug(f"Sending with Buzzer_ON_OFF={buzzer_command_value} (Silent mode HA toggle is ON: {self._current_beeper_enabled})")
+        _LOGGER.debug(f"Sending with Buzzer_ON_OFF={buzzer_command_value} (Beeper is {'ENABLED' if self._current_beeper_enabled else 'DISABLED'})")
 
         if self._has_anti_direct_blow:
             opt += ',"AntiDirectBlow"'
@@ -1281,11 +1281,11 @@ class GreeClimate(ClimateEntity):
             return
 
         if new_state.state == STATE_ON:
-            self._current_beeper_enabled = True # Silent mode ON
-            _LOGGER.info('Silent mode enabled (beeper will be turned off with commands).')
+            self._current_beeper_enabled = True  # Beeper ON (not silent)
+            _LOGGER.info('Beeper enabled (audible).')
         else: # STATE_OFF or other
-            self._current_beeper_enabled = False # Silent mode OFF
-            _LOGGER.info('Silent mode disabled (beeper will be turned on with commands).')
+            self._current_beeper_enabled = False  # Beeper OFF (silent)
+            _LOGGER.info('Beeper disabled (silent).')
 
 
     @property


### PR DESCRIPTION
Fixes #304

- Fixed beeper initialization to correctly handle both ON and OFF states at startup.
- Corrected and clarified log messages for beeper state changes.
- Improved README documentation for the beeper option.