### PR TITLE
Add support for Gree MC31-00/F Central Air Conditioner Remote Control Module

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-    "files.associations": {
-        "*.yaml": "home-assistant"
-    }
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "files.associations": {
+        "*.yaml": "home-assistant"
+    }
+}

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ The integration can be added from the Home Assistant UI.
    | `name` | Name | `string` (e.g., `First AC`) | `false` | `Gree Climate` |
    | `host` | IP Address of AC | `string` (e.g., `192.168.1.101`) | `true` | |
    | `port` | Port number to connect to the device | `integer` (e.g., `7000`) | `false` | `7000` |
-   | `mac` | MAC address of the device | `string` (e.g., `20fabb123456`) <br> **NOTE: Format can be XX:XX:XX:XX:XX:XX, XX-XX-XX-XX-XX-XX, xxxxxxxxxxxx or xxxxxxxxxxxx@yyyyyyyyyyyy depending on your model** | `true` | 
+   | `mac` | MAC address of the device | `string` (e.g., `20fabb123456`) <br> **NOTE: Format can be XX:XX:XX:XX:XX:XX, XX-XX-XX-XX-XX-XX, xxxxxxxxxxxx or xxxxxxxxxxxx@yyyyyyyyyyyy (for VRF units) depending on your model** | `true` | 
    | `encryption_key` | Custom encryption key | `string` (e.g., `A1B2C3D4E5F6`) | `false` | *(auto-fetched if empty)* |
    | `encryption_version` | Encryption version | `integer` (e.g., `2`) | `false` | `1` | |
    | `hvac_modes` | Standard Home Assistant HVAC Modes to enable | `list[string]` (e.g. `["auto", "cool", "dry", "fan_only", "off"]`) | `false` | `["auto", "cool", "dry", "fan_only", "heat", "heat_cool", "off"]` |

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Tested on the following hardware:
 - TOSOT TW12HXP2A1D
 - Toyotomi Izuru TRN/TRG-828ZR
 - Wilfa Cool9 Connected
+- Gree MC31-00/F Central Air Conditioner Remote Control Module
 
 Tested on Home Assistant 2025.6.3 
 
@@ -84,7 +85,7 @@ The integration can be added from the Home Assistant UI.
    | `name` | Name | `string` (e.g., `First AC`) | `false` | `Gree Climate` |
    | `host` | IP Address of AC | `string` (e.g., `192.168.1.101`) | `true` | |
    | `port` | Port number to connect to the device | `integer` (e.g., `7000`) | `false` | `7000` |
-   | `mac` | MAC address of the device | `string` (e.g., `20fabb123456`) <br> **NOTE: Format can be XX:XX:XX:XX:XX:XX, XX-XX-XX-XX-XX-XX or xxxxxxxxxxxx depending on your model** | `true` | 
+   | `mac` | MAC address of the device | `string` (e.g., `20fabb123456`) <br> **NOTE: Format can be XX:XX:XX:XX:XX:XX, XX-XX-XX-XX-XX-XX, xxxxxxxxxxxx or xxxxxxxxxxxx@yyyyyyyyyyyy depending on your model** | `true` | 
    | `encryption_key` | Custom encryption key | `string` (e.g., `A1B2C3D4E5F6`) | `false` | *(auto-fetched if empty)* |
    | `encryption_version` | Encryption version | `integer` (e.g., `2`) | `false` | `1` | |
    | `hvac_modes` | Standard Home Assistant HVAC Modes to enable | `list[string]` (e.g. `["auto", "cool", "dry", "fan_only", "off"]`) | `false` | `["auto", "cool", "dry", "fan_only", "heat", "heat_cool", "off"]` |

--- a/custom_components/gree/climate.py
+++ b/custom_components/gree/climate.py
@@ -546,7 +546,7 @@ class GreeClimate(ClimateEntity):
 
     def UpdateHATargetTemperature(self):
         # Sync set temperature to HA. If 8℃ heating is active we set the temp in HA to 8℃ so that it shows the same as the AC display.
-        if (int(self._acOptions['StHt']) == 1):
+        if self._acOptions['StHt'] and (int(self._acOptions['StHt']) == 1):
             self._target_temperature = 8
             _LOGGER.info('HA target temp set according to HVAC state to 8℃ since 8℃ heating mode is active')
         else:
@@ -649,9 +649,9 @@ class GreeClimate(ClimateEntity):
                     self.hass.states.async_set(self._sleep_entity_id, self._current_sleep, attr)
         _LOGGER.debug('HA sleep option set according to HVAC state to: ' + str(self._current_sleep))
         # Sync current HVAC 8℃ heat option to HA
-        if (self._acOptions['StHt'] == 1):
+        if (self._acOptions['StHt'] and self._acOptions['StHt'] == 1):
             self._current_eightdegheat = STATE_ON
-        elif (self._acOptions['StHt'] == 0):
+        elif (self._acOptions['StHt'] and self._acOptions['StHt'] == 0):
             self._current_eightdegheat = STATE_OFF
         else:
             self._current_eightdegheat = STATE_UNKNOWN

--- a/custom_components/gree/climate.py
+++ b/custom_components/gree/climate.py
@@ -527,7 +527,7 @@ class GreeClimate(ClimateEntity):
                 filtered_p.append(str(val))
 
         
-        _command_value = 0 if self._current_beeper_enabled else 1
+        buzzer_command_value = 0 if self._current_beeper_enabled else 1
         filtered_opt.append('"Buzzer_ON_OFF"')
         filtered_p.append(str(buzzer_command_value))
         _LOGGER.debug(f"Sending with Buzzer_ON_OFF={buzzer_command_value} (Beeper is {'ENABLED' if self._current_beeper_enabled else 'DISABLED'})")


### PR DESCRIPTION
**Summary**
Adds support for the MC31-00/F model and likely other VRF AC modules with sub-units.

**Details**
Matches Gree+ app behavior when adding a VRF AC:
`<sub_mac_address>@<parent_mac_address>
`
(Can be copied directly from the app.)

Changes are backward compatible and should not affect other devices.

**Bug Fixes**

- Resolved an issue in GreeGetValues where requesting a single value returned a list. 
   SyncState expected a direct value, leading it to incorrectly assume certain features were unsupported.
- Resolved some acess to non-initialized values cauesd an exception.

**Known Issue**
For VRF AC units, state changes are not immediately reflected in the UI—they only appear after the periodic update() runs.
This does not affect other AC units.
I'm still investigating the issue, but this limitation should not block merging, as the new model support remains functional.