### PR TITLE
Add Gree Clivia to list of supported devices

### DIFF
--- a/supported-devices.md
+++ b/supported-devices.md
@@ -14,6 +14,7 @@ Tested on the following hardware:
 - AC Gree 3VIR24HP230V1AH
 - Ac Gree Pulsar GWH09AGAXB-K6DNA1B (encryption version 2)
 - Gree MC31-00/F Central Air Conditioner Remote Control Module
+- AC Gree Clivia (encryption version 2)
 
 ## Kolin
 - Kolin KAG-100WCINV (encryption version 2)


### PR DESCRIPTION
Added 3 Gree Clivia's (firmware version `v2.10` according to Gree app) using this integration a few weeks ago and still running perfect.

NOTE: needs encryption version 2 to work (otherwise devices are unavailable in Home Assistant)