### PR TITLE
Fix unique_id for VRF

### DIFF
--- a/custom_components/gree/climate.py
+++ b/custom_components/gree/climate.py
@@ -164,7 +164,7 @@ class GreeClimate(ClimateEntity):
         else:
             self._sub_mac_addr = self._mac_addr = mac_addr_str
         self._timeout = timeout
-        self._unique_id = f"{DOMAIN}_{self._mac_addr}"
+        self._unique_id = f"{DOMAIN}_{self._sub_mac_addr}"
         self._device_online = None
         self._online_attempts = 0
         self._max_online_attempts = max_online_attempts


### PR DESCRIPTION
In the **VRF module**, the `self._mac_addr` is shared across all instances, which resulted in duplicate `self._unique_id` values.

Note that for non VRF, the `_sub_mac_addr` and `self._mac_addr` are the same. 
This helps to simplfiy the code, as there is no need to distinguish between different cases.