### PR TITLE
Add auto-discovery

### DIFF
--- a/custom_components/gree/config_flow.py
+++ b/custom_components/gree/config_flow.py
@@ -39,7 +39,7 @@ from .const import (
     DOMAIN,
     OPTION_KEYS,
 )
-from .gree_protocol import test_connection
+from .gree_protocol import test_connection, discover_gree_devices, detect_device_encryption
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -51,12 +51,153 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     def __init__(self) -> None:
         self._data: dict[str, any] = {}
+        self._discovered_devices: list[dict] = []
+        self._selected_device: dict | None = None
 
     async def async_step_user(self, user_input: dict | None = None) -> FlowResult:
-        """Handle the initial step."""
+        """Handle the initial step - show discovery or manual entry."""
+        if user_input is not None:
+            if user_input.get("discovery") == "discover":
+                return await self.async_step_discovery()
+            else:
+                return await self.async_step_manual()
+
+        # Show discovery vs manual choice
+        data_schema = vol.Schema(
+            {
+                vol.Required("discovery", default="discover"): selector.SelectSelector(
+                    selector.SelectSelectorConfig(
+                        options=["discover", "manual"],
+                        translation_key="discovery_method",
+                    )
+                )
+            }
+        )
+        return self.async_show_form(step_id="user", data_schema=data_schema)
+
+    async def async_step_discovery(self, user_input: dict | None = None) -> FlowResult:
+        """Handle device discovery."""
+        if user_input is not None:
+            # User selected a discovered device
+            selected_device = user_input["device"]
+
+            for device in self._discovered_devices:
+                device_id = f"{device['mac']}_{device['host']}"
+                if device_id == selected_device:
+                    # Check if already configured
+                    await self.async_set_unique_id(device["mac"])
+                    self._abort_if_unique_id_configured()
+
+                    # Store selected device for next step
+                    self._selected_device = device
+                    return await self.async_step_detect_encryption()
+
+            # If no matching device found, something went wrong - go to manual
+            return await self.async_step_manual()
+
+        # Discover devices
+        self._discovered_devices = await discover_gree_devices(timeout=5)
+
+        if not self._discovered_devices:
+            # No devices found, go to manual entry
+            return await self.async_step_manual()
+
+        # Create device selection options
+        device_options = {}
+        for device in self._discovered_devices:
+            device_id = f"{device['mac']}_{device['host']}"
+            device_options[device_id] = f"IP: {device['host']}, MAC: {device['mac']}"
+
+        data_schema = vol.Schema({vol.Required("device"): vol.In(device_options)})
+
+        return self.async_show_form(step_id="discovery", data_schema=data_schema, description_placeholders={"devices_found": str(len(self._discovered_devices))})
+
+    async def async_step_detect_encryption(self, user_input: dict | None = None) -> FlowResult:
+        """Detect encryption version and configure device."""
+        if user_input is not None:
+            # User entered device name, proceed with setup
+            device_name = user_input[CONF_NAME]
+
+            # Create final configuration
+            self._data = {
+                CONF_NAME: device_name,
+                CONF_HOST: self._selected_device["host"],
+                CONF_MAC: self._selected_device["mac"],
+                CONF_PORT: self._selected_device["port"],
+                CONF_ENCRYPTION_KEY: "",
+                CONF_ENCRYPTION_VERSION: self._selected_device["encryption_version"],
+            }
+
+            # Test the connection
+            is_connection_valid = await test_connection(self._data)
+            if not is_connection_valid:
+                return self.async_show_form(
+                    step_id="detect_encryption",
+                    data_schema=vol.Schema(
+                        {
+                            vol.Required(CONF_NAME, default=device_name): str,
+                        }
+                    ),
+                    errors={"base": "cannot_connect"},
+                )
+
+            return self.async_create_entry(title=device_name, data=self._data)
+
+        # Detect encryption version for selected device
+        mac_addr = self._selected_device["mac"]
+        ip_addr = self._selected_device["host"]
+        port = self._selected_device["port"]
+
+        encryption_version = await detect_device_encryption(mac_addr, ip_addr, port)
+
+        if encryption_version is None:
+            # Could not detect encryption, pre-fill manual form with discovered device info
+            self._data = {
+                CONF_NAME: self._selected_device["name"],
+                CONF_HOST: self._selected_device["host"],
+                CONF_MAC: self._selected_device["mac"],
+                CONF_PORT: self._selected_device["port"],
+                CONF_ENCRYPTION_KEY: "",
+                CONF_ENCRYPTION_VERSION: 1,  # Default to version 1
+            }
+            # Show manual form with error about encryption detection failure
+            return self.async_show_form(
+                step_id="manual",
+                data_schema=vol.Schema(
+                    {
+                        vol.Required(CONF_NAME, default=self._data.get(CONF_NAME, "")): str,
+                        vol.Required(CONF_HOST, default=self._data.get(CONF_HOST, "")): str,
+                        vol.Required(CONF_MAC, default=self._data.get(CONF_MAC, "")): str,
+                        vol.Required(CONF_PORT, default=self._data.get(CONF_PORT, DEFAULT_PORT)): int,
+                        vol.Optional(CONF_ENCRYPTION_KEY, default=self._data.get(CONF_ENCRYPTION_KEY, "")): str,
+                        vol.Optional(CONF_UID): int,
+                        vol.Optional(CONF_ENCRYPTION_VERSION, default=self._data.get(CONF_ENCRYPTION_VERSION, 1)): int,
+                    }
+                ),
+                errors={"base": "cannot_connect"},
+            )
+
+        # Store detected encryption version
+        self._selected_device["encryption_version"] = encryption_version
+
+        # Show device naming form with detected info
+        data_schema = vol.Schema(
+            {
+                vol.Required(CONF_NAME, default=self._selected_device["name"]): str,
+            }
+        )
+
+        return self.async_show_form(step_id="detect_encryption", data_schema=data_schema)
+
+    async def async_step_manual(self, user_input: dict | None = None) -> FlowResult:
+        """Handle manual device entry."""
         errors = {}
         if user_input is not None:
             self._data.update(user_input)
+
+            # Check if already configured by MAC
+            await self.async_set_unique_id(self._data[CONF_MAC])
+            self._abort_if_unique_id_configured()
 
             is_connection_valid = await test_connection(self._data)
             if not is_connection_valid:
@@ -65,7 +206,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 return self.async_create_entry(title=user_input[CONF_NAME], data=self._data)
 
         # Set defaults from user_input if present, else use hardcoded defaults
-        defaults = user_input or {}
+        defaults = user_input or self._data
         data_schema = vol.Schema(
             {
                 vol.Required(CONF_NAME, default=defaults.get(CONF_NAME, "")): str,
@@ -77,7 +218,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 vol.Optional(CONF_ENCRYPTION_VERSION, default=defaults.get(CONF_ENCRYPTION_VERSION, 1)): int,
             }
         )
-        return self.async_show_form(step_id="user", data_schema=data_schema, errors=errors)
+        return self.async_show_form(step_id="manual", data_schema=data_schema, errors=errors)
 
     async def async_step_import(self, import_data: dict) -> FlowResult:
         """Handle configuration via YAML import."""

--- a/custom_components/gree/config_flow.py
+++ b/custom_components/gree/config_flow.py
@@ -96,7 +96,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             return await self.async_step_manual()
 
         # Discover devices
-        self._discovered_devices = await discover_gree_devices(timeout=5)
+        self._discovered_devices = await discover_gree_devices(self.hass)
 
         if not self._discovered_devices:
             # No devices found, go to manual entry

--- a/custom_components/gree/gree_protocol.py
+++ b/custom_components/gree/gree_protocol.py
@@ -7,6 +7,7 @@ import asyncio
 import base64
 import logging
 import socket
+import time
 
 # Third-party imports
 try:
@@ -32,13 +33,12 @@ GENERIC_GREE_DEVICE_KEY = "a3K8Bx%2r8Y7#xDh"
 GENERIC_GREE_DEVICE_KEY_GCM = b"{yxAHAY_Lm6pbC/<"
 
 
-async def FetchResult(cipher, ip_addr, port, json_data, encryption_version=1):
+async def FetchResult(cipher, ip_addr, port, json_data, encryption_version=1, max_retries=8):
     """Send a request to a Gree device and fetch the result, with retries and timeouts."""
 
     _LOGGER.debug(f"Fetching device at: {ip_addr}:{port}, data sent: {json_data})")
 
     timeout = 2
-    max_retries = 8
 
     for attempt in range(max_retries):
         clientSock = None
@@ -123,13 +123,13 @@ async def test_connection(config):
         return False
 
 
-async def GetDeviceKey(mac_addr, ip_addr, port):
+async def GetDeviceKey(mac_addr, ip_addr, port, max_retries=8):
     _LOGGER.debug("Retrieving HVAC encryption key")
     cipher = AES.new(GENERIC_GREE_DEVICE_KEY.encode("utf8"), AES.MODE_ECB)
     pack = base64.b64encode(cipher.encrypt(Pad(f'{{"mac":"{mac_addr}","t":"bind","uid":0}}').encode("utf8"))).decode("utf-8")
     jsonPayloadToSend = f'{{"cid": "app","i": 1,"pack": "{pack}","t":"pack","tcid":"{mac_addr}","uid": 0}}'
     try:
-        result = await FetchResult(cipher, ip_addr, port, jsonPayloadToSend)
+        result = await FetchResult(cipher, ip_addr, port, jsonPayloadToSend, max_retries=max_retries)
         _LOGGER.debug(f"GetDeviceKey: FetchResult: {result}")
         key = result["key"].encode("utf8")
     except Exception:
@@ -154,13 +154,13 @@ def EncryptGCM(key, plaintext):
     return (pack, tag)
 
 
-async def GetDeviceKeyGCM(mac_addr, ip_addr, port):
+async def GetDeviceKeyGCM(mac_addr, ip_addr, port, max_retries=8):
     _LOGGER.debug("Retrieving HVAC encryption key (GCM)")
     plaintext = f'{{"cid":"{mac_addr}", "mac":"{mac_addr}","t":"bind","uid":0}}'
     pack, tag = EncryptGCM(GENERIC_GREE_DEVICE_KEY_GCM, plaintext)
     jsonPayloadToSend = f'{{"cid": "app","i": 1,"pack": "{pack}","t":"pack","tcid":"{mac_addr}","uid": 0, "tag" : "{tag}"}}'
     try:
-        result = await FetchResult(GetGCMCipher(GENERIC_GREE_DEVICE_KEY_GCM), ip_addr, port, jsonPayloadToSend, encryption_version=2)
+        result = await FetchResult(GetGCMCipher(GENERIC_GREE_DEVICE_KEY_GCM), ip_addr, port, jsonPayloadToSend, encryption_version=2, max_retries=max_retries)
         _LOGGER.debug(f"GetDeviceKeyGCM: FetchResult: {result}")
         key = result["key"].encode("utf8")
     except Exception:
@@ -169,3 +169,116 @@ async def GetDeviceKeyGCM(mac_addr, ip_addr, port):
     else:
         _LOGGER.debug(f"Fetched device encryption key: {str(key)}")
         return key
+
+
+async def discover_gree_devices(timeout=3):
+    """Discover Gree devices on the local network using UDP broadcast."""
+    _LOGGER.debug("Starting Gree device discovery...")
+
+    BROADCAST_PORT = 7000
+    DISCOVERY_MESSAGE = b'{"t":"scan"}'
+
+    # Set up UDP socket for broadcast
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+    sock.settimeout(timeout)
+    sock.bind(("", 0))
+
+    devices = []
+
+    try:
+        # Send broadcast
+        sock.sendto(DISCOVERY_MESSAGE, ("255.255.255.255", BROADCAST_PORT))
+        _LOGGER.debug("Sent discovery packet, waiting for replies...")
+
+        start = time.time()
+        while time.time() - start < timeout:
+            try:
+                data, addr = sock.recvfrom(1024)
+                try:
+                    # Try to parse as JSON and decrypt if possible
+                    response = simplejson.loads(data.decode(errors="ignore"))
+                    if "pack" in response:
+                        pack = response["pack"]
+                        decoded_pack = base64.b64decode(pack)
+
+                        # Discovery responses typically use level 1 encryption (ECB mode)
+                        # But we need to test which encryption the device actually uses for communication
+                        pack_json = None
+
+                        try:
+                            cipher = AES.new(GENERIC_GREE_DEVICE_KEY.encode("utf-8"), AES.MODE_ECB)
+                            decrypted_pack = cipher.decrypt(decoded_pack)
+                            # Remove null bytes and trailing data after last }
+                            decoded_text = decrypted_pack.decode("utf-8", errors="ignore").replace("\x0f", "")
+                            last_brace = decoded_text.rfind("}")
+                            if last_brace != -1:
+                                clean_text = decoded_text[: last_brace + 1]
+                            else:
+                                clean_text = decoded_text
+                            pack_json = simplejson.loads(clean_text)
+                            _LOGGER.debug(f"Decrypted discovery response from {addr}")
+                        except Exception as e:
+                            _LOGGER.debug(f"Could not decrypt discovery response from {addr}: {e}")
+                            continue
+
+                        # If we successfully decrypted and got device info
+                        if pack_json and pack_json.get("t") == "dev":
+                            mac_addr = pack_json.get("mac", "")
+                            if not mac_addr:
+                                _LOGGER.debug(f"No MAC address in response from {addr}")
+                                continue
+
+                            # Just collect basic device info for now - encryption detection happens later
+                            device_info = {
+                                "name": pack_json.get("name", "") or f"Gree {mac_addr[-4:]}",
+                                "host": addr[0],
+                                "port": BROADCAST_PORT,
+                                "mac": mac_addr,
+                                "brand": pack_json.get("brand", "gree"),
+                                "model": pack_json.get("model", "gree"),
+                                "version": pack_json.get("ver", ""),
+                            }
+                            devices.append(device_info)
+                            _LOGGER.debug(f"Discovered Gree device: {device_info}")
+                        else:
+                            _LOGGER.debug(f"Invalid or missing device info from {addr}")
+                    else:
+                        _LOGGER.debug(f"Received response without pack from {addr}: {response}")
+                except Exception as e:
+                    _LOGGER.debug(f"Could not parse response from {addr}: {e}")
+            except socket.timeout:
+                break
+    finally:
+        sock.close()
+
+    _LOGGER.debug(f"Discovery completed, found {len(devices)} devices")
+    return devices
+
+
+async def detect_device_encryption(mac_addr, ip_addr, port):
+    """Test which encryption version a device uses for communication."""
+    _LOGGER.debug(f"Detecting encryption version for device {mac_addr} at {ip_addr}:{port}")
+
+    # Test encryption version 1 first
+    try:
+        _LOGGER.debug(f"Testing encryption version 1 for device {mac_addr}")
+        key = await GetDeviceKey(mac_addr, ip_addr, port, max_retries=1)
+        if key:
+            _LOGGER.debug(f"Device {mac_addr} uses encryption version 1")
+            return 1
+    except Exception as e:
+        _LOGGER.debug(f"Encryption version 1 failed for device {mac_addr}: {e}")
+
+    # Test encryption version 2
+    try:
+        _LOGGER.debug(f"Testing encryption version 2 for device {mac_addr}")
+        key = await GetDeviceKeyGCM(mac_addr, ip_addr, port, max_retries=1)
+        if key:
+            _LOGGER.debug(f"Device {mac_addr} uses encryption version 2")
+            return 2
+    except Exception as e:
+        _LOGGER.debug(f"Encryption version 2 failed for device {mac_addr}: {e}")
+
+    _LOGGER.error(f"Could not determine encryption version for device {mac_addr}")
+    return None

--- a/custom_components/gree/translations/en.json
+++ b/custom_components/gree/translations/en.json
@@ -3,10 +3,36 @@
     "error": {
       "cannot_connect": "Unable to connect to the device. Please check the network connection and try again."
     },
+    "abort": {
+      "already_configured": "A device with this MAC address is already configured."
+    },
     "title": "Gree Climate",
     "description": "Configure your Gree air conditioner",
     "step": {
       "user": {
+        "title": "Gree Climate Setup",
+        "description": "Choose how to add your Gree air conditioner",
+        "data": {
+          "discovery": "Setup Method"
+        }
+      },
+      "discovery": {
+        "title": "Discovered Devices",
+        "description": "Found {devices_found} Gree device(s). Select one to add or choose manual setup.",
+        "data": {
+          "device": "Device"
+        }
+      },
+      "detect_encryption": {
+        "title": "Configure Device",
+        "description": "Device connection successful. Enter a name for this device.",
+        "data": {
+          "name": "Device Name"
+        }
+      },
+      "manual": {
+        "title": "Manual Setup",
+        "description": "Enter the details for your Gree air conditioner",
         "data": {
           "name": "Name",
           "host": "IP Address",
@@ -50,6 +76,12 @@
     }
   },
   "selector": {
+    "discovery_method": {
+      "options": {
+        "discover": "Discover devices automatically",
+        "manual": "Add device manually"
+      }
+    },
     "hvac_modes": {
       "options": {
         "auto": "Auto",


### PR DESCRIPTION
Closes #365

Code might not be optimal, some repetition here and there, but it's by the book still.
It _seems_ like decoding the UDP response always uses the same encryption. So in theory we could show more info (model/firmware/etc) in the 2nd step, but I wanted to keep it simple for now.

First step:
<img width="414" height="347" alt="image" src="https://github.com/user-attachments/assets/fe5e353a-eb87-4504-959a-1d0f3aeb5f5a" />

Second step (will show manual config if no devices found):
<img width="503" height="368" alt="image" src="https://github.com/user-attachments/assets/afb45135-b5a4-401f-b845-714f80055082" />
Third step (will try to decode the data, on fail will show manual config with error and pre-filled fields)
<img width="463" height="337" alt="image" src="https://github.com/user-attachments/assets/e54aecf1-1033-4c9e-b4f2-f4c33cf4aa0d" />
Possible third step message:
<img width="425" height="221" alt="image" src="https://github.com/user-attachments/assets/6858b67a-d5fc-472b-90e3-9ccd12d135cf" />

On error when selecting a found device:
<img width="574" height="808" alt="image" src="https://github.com/user-attachments/assets/1e8a4486-cbdf-4bd3-8a6a-bd0eb2d0d2c2" />
