### PR TITLE
Add translatable names for room humidity and external temperature sensors

### DIFF
--- a/custom_components/gree/translations/en.json
+++ b/custom_components/gree/translations/en.json
@@ -158,6 +158,16 @@
         "description": "Select a temperature sensor entity to use instead of the built-in AC sensor. Choose 'None' to use the built-in sensor."
       }
     },
+    "sensor": {
+      "outside_temperature": {
+        "name": "Outside Temperature",
+        "description": "Shows the outside temperature measured by the air conditioner's external sensor."
+      },
+      "room_humidity": {
+        "name": "Room Humidity",
+        "description": "Shows the room humidity level measured by the air conditioner's internal sensor."
+      }
+    },
     "switch": {
       "xfan": {
         "name": "X-Fan",


### PR DESCRIPTION
Also took the opportunity to standardize the file in order to use our `GreeEntityDescription` class.

Both sensors will need to be recreated/updated once the integration loads the new code. Either remove/re-add the entry or manually delete them both, then re-create entities so that the new sensors use the new id generated.
