### PR TITLE
fix: auto-clear stale encryption key after repeated update failures

### DIFF
--- a/custom_components/gree/climate.py
+++ b/custom_components/gree/climate.py
@@ -108,6 +108,12 @@ async def create_gree_device(hass, config):
 # update() interval
 SCAN_INTERVAL = timedelta(seconds=60)
 
+# After this many consecutive update failures, discard the cached encryption
+# key so the next update re-binds. Recovers from device-side key rotation
+# (power outage, router restart, WiFi re-association) without a manual reload.
+# Only applied to auto-acquired keys; user-configured keys are never cleared.
+STALE_KEY_THRESHOLD = 3
+
 
 async def async_setup_entry(hass, entry, async_add_devices):
     """Set up Gree climate from a config entry."""
@@ -201,6 +207,12 @@ class GreeClimate(ClimateEntity):
 
         self.encryption_version = encryption_version
         self.CIPHER = None
+
+        # Tracks whether the user explicitly configured the key. Auto-acquired
+        # keys may be discarded after repeated failures (see STALE_KEY_THRESHOLD);
+        # user-configured keys are preserved even under persistent timeouts.
+        self._user_provided_key = bool(encryption_key)
+        self._consecutive_update_failures = 0
 
         if encryption_key:
             _LOGGER.info(f"{self._name}: Using configured encryption key: {encryption_key}")
@@ -466,6 +478,28 @@ class GreeClimate(ClimateEntity):
         self.UpdateHAOutsideTemperature()
         self.UpdateHARoomHumidity()
 
+    def _handle_comms_failure(self):
+        # Discard an auto-acquired key after repeated failures so the next update
+        # re-binds and recovers from a device-side key rotation. User-provided
+        # keys are preserved — a silent override would surprise the user.
+        self._consecutive_update_failures += 1
+        if self._consecutive_update_failures < STALE_KEY_THRESHOLD:
+            return
+        if self._user_provided_key:
+            _LOGGER.warning(
+                f"{self._name}: {self._consecutive_update_failures} consecutive update failures "
+                f"with a user-configured encryption key. Not auto-clearing; reload the integration "
+                f"or update the key in options if the device has rotated its key."
+            )
+            return
+        _LOGGER.warning(
+            f"{self._name}: {self._consecutive_update_failures} consecutive update failures; "
+            f"discarding cached encryption key to trigger re-bind on next update."
+        )
+        self._encryption_key = None
+        self.CIPHER = None
+        self._consecutive_update_failures = 0
+
     async def SyncState(self, acOptions={}):
         # Fetch current settings from HVAC
         _LOGGER.debug(f"{self._name}: Starting device state sync")
@@ -563,7 +597,9 @@ class GreeClimate(ClimateEntity):
             if not self._disable_available_check:
                 _LOGGER.info(f"{self._name}: Device marked offline after failed communication")
                 self._device_online = False
+            self._handle_comms_failure()
         else:
+            self._consecutive_update_failures = 0
             if not self._disable_available_check:
                 if not self._device_online:
                     self._device_online = True
@@ -586,6 +622,7 @@ class GreeClimate(ClimateEntity):
                         if not self._disable_available_check:
                             _LOGGER.info(f"{self._name}: Device marked offline after failed send attempt")
                             self._device_online = False
+                        self._handle_comms_failure()
             else:
                 # loop used once for Gree Climate initialisation only
                 self._firstTimeRun = False


### PR DESCRIPTION
Closes #441.

## Summary

When a Gree AC rotates its session key (reproduced by putting the unit into Wi-Fi re-pairing mode via **MODE + WIFI**), the integration kept encrypting requests with the stale cached key forever — the climate entity stayed `Unavailable` until the user manually reloaded the integration.

This patch tracks consecutive update failures and, after a threshold, discards the cached key so the existing `async_update` re-bind path auto-recovers on the next poll tick. User-configured keys are preserved.

See #441 for full symptoms, logs, root-cause analysis, and repro steps.

## Change

Single-file change (~35 lines added, 0 removed) in `custom_components/gree/climate.py`:

- `STALE_KEY_THRESHOLD = 3` module-level constant
- Two new attrs in `__init__`:
  - `_user_provided_key = bool(encryption_key)` — remembers whether the user supplied a static key at setup
  - `_consecutive_update_failures = 0`
- New `_handle_comms_failure()` helper:
  - Increments the counter
  - At threshold, if key was auto-acquired → clears `_encryption_key` + `CIPHER`, logs warning, resets counter
  - At threshold, if key was user-configured → logs warning only (no silent override)
- `SyncState` resets the counter on successful `GreeGetValues`, calls `_handle_comms_failure()` in the existing `except` blocks for both `GreeGetValues` and `SendStateToAc`

No changes to the happy path — only triggers when comms are already failing.

## Why the `_user_provided_key` guard

`CONF_ENCRYPTION_KEY` is an optional user-editable field in the config flow. Users who deliberately set a static key would otherwise see it silently replaced by whatever `bind` returns after a transient network blip. With the guard, blank-key setups (the common case, auto-bind) get auto-healing; users who typed a key get a warning but no silent override.

## Recovery mechanism (no new code path needed)

Existing `async_update` already re-binds when `_encryption_key is None`:

```python
if not self._encryption_key:
    key = await GetDeviceKey(...)  # or GetDeviceKeyGCM
    if key:
        self._encryption_key = key
        self.CIPHER = ...
        await self.SyncState()
```

This PR just triggers that path after repeated failures instead of only at first boot.

## Scope

- Fix only applied in `climate.py`. Other platforms (`switch.py`, `sensor.py`, `number.py`, `select.py`) share the climate instance via `hass.data[DOMAIN][entry.entry_id]["device"]` (see `entity.py`) — they don't cache their own keys, so no change needed there.
- No test suite exists in the repo, so no tests added. Happy to add a small pytest harness if you'd like one.

## Test plan

- [x] `py_compile` passes
- [x] Manual repro per #441 — entity self-heals within `STALE_KEY_THRESHOLD × scan_interval` (default 3 × 60s = 3 min) after Wi-Fi re-pairing, no manual reload needed
- [ ] Confirm no regression on a healthy device (3 successful polls in a row, counter stays at 0)
- [ ] Confirm user-configured key path logs the warning and does NOT clear the key