### PR TITLE
fix: complete VRF device_info fix started in #338 — sub-units still share one HA device

### DIFF
--- a/custom_components/gree/climate.py
+++ b/custom_components/gree/climate.py
@@ -759,7 +759,7 @@ class GreeClimate(ClimateEntity):
     def device_info(self) -> DeviceInfo:
         """Return device information."""
         return DeviceInfo(
-            identifiers={(DOMAIN, self._mac_addr)},
+            identifiers={(DOMAIN, self._sub_mac_addr)},
             name=self._name,
             manufacturer="Gree",
         )

--- a/custom_components/gree/entity.py
+++ b/custom_components/gree/entity.py
@@ -59,16 +59,16 @@ class GreeEntity(Entity):
             elif self.entity_description.icon is not None:
                 self._attr_icon = self.entity_description.icon
 
-            self._attr_unique_id = f"{self._device._mac_addr}_{self.entity_description.key}"
+            self._attr_unique_id = f"{self._device._sub_mac_addr}_{self.entity_description.key}"
 
     @property
     def device_info(self) -> DeviceInfo:
         """Return device information."""
         return DeviceInfo(
-            identifiers={(DOMAIN, self._device._mac_addr)},
+            identifiers={(DOMAIN, self._device._sub_mac_addr)},
             name=self._device._name,
             manufacturer="Gree",
-            connections={(CONNECTION_NETWORK_MAC, self._device._mac_addr)},
+            connections={(CONNECTION_NETWORK_MAC, self._device._sub_mac_addr)},
         )
 
     @property


### PR DESCRIPTION
## Problem

For Gree multi-split VRF gateways (one WiFi module controlling multiple indoor units, e.g. `GR-Gcloud`), all indoor units were grouped under a single shared HA device. This made it impossible to assign individual units to different rooms/areas.

Root cause: `device_info` used `_mac_addr` (the gateway MAC, shared by all sub-units) instead of `_sub_mac_addr` (the unique per-unit sub-MAC).

This is a continuation of #338, which fixed `unique_id` in `climate.py` to use `_sub_mac_addr` but left `device_info` in `climate.py` and both `unique_id` + `device_info` in `entity.py` still using the gateway MAC.

## Changes

- `climate.py`: `device_info` identifiers now use `self._sub_mac_addr` instead of `self._mac_addr`
- `entity.py`: both `_attr_unique_id` and `device_info` identifiers now use `self._device._sub_mac_addr`

## Result

Each VRF indoor unit appears as its own separate HA device and can be assigned to its own room/area independently.

## Migration note for existing users

If you already have a multi-split VRF setup configured, after updating you will see a lingering **ghost shared device** (the old combined device with the gateway MAC). HA will keep it around because it was previously in your device registry.

To clean it up: go to **Settings → Devices & Services → Devices**, find the old shared Gree device (it will have no active entities), and delete it. The 5 individual devices will remain unaffected.

## Tested on

- Gree VRF gateway (`GR-Gcloud` type) with 5 indoor units, sub-MACs in `subMAC@gatewayMAC` format
- Home Assistant OS 17.3 / HA Core 2026.5.3