### PR TITLE
Fix YAML import and handle optional configuration values

### DIFF
--- a/custom_components/gree/config_flow.py
+++ b/custom_components/gree/config_flow.py
@@ -294,7 +294,24 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_import(self, import_data: dict) -> FlowResult:
         """Handle configuration via YAML import."""
-        return await self.async_step_user(import_data)
+        self._data.update(import_data)
+
+        self._data.setdefault(CONF_ENCRYPTION_KEY, "")
+        self._data.setdefault(CONF_UID, 0)
+        self._data.setdefault(CONF_PORT, DEFAULT_PORT)
+        self._data.setdefault(CONF_ENCRYPTION_VERSION, 1)
+
+        await self.async_set_unique_id(self._data[CONF_MAC])
+        self._abort_if_unique_id_configured()
+
+        is_connection_valid = await test_connection(self._data)
+        if not is_connection_valid:
+            return self.async_abort(reason="cannot_connect")
+
+        return self.async_create_entry(
+            title=self._data[CONF_NAME],
+            data=self._data,
+        )
 
     @staticmethod
     @callback


### PR DESCRIPTION
## Summary

Fixes YAML-based configuration imports.

The integration currently declares a YAML configuration schema and documents YAML configuration in the README, however `async_step_import()` forwards directly to `async_step_user()`, causing imported entries to stop at the manual configuration step instead of creating config entries automatically.

Additionally, `test_connection()` expects optional fields such as `encryption_key` and `uid` to be present, resulting in:

```text
KeyError: 'encryption_key'
```

when using the documented YAML configuration examples.

## Changes

* Process YAML imports directly in `async_step_import()`
* Populate defaults for optional configuration values before connection testing
* Validate connectivity before creating entries
* Preserve unique ID handling to prevent duplicate entries
* Create config entries automatically from YAML definitions

## Tested

Tested successfully on Home Assistant 2026.6.1 with multiple Gree units defined through YAML configuration.

The following configuration imports correctly and creates config entries automatically:

```yaml
gree:
  - name: "Living Room"
    host: "192.168.1.101"
    mac: "20-FA-BB-12-34-56"
    encryption_version: 1
```
